### PR TITLE
override get_menu_items not menuitems

### DIFF
--- a/elcid/__init__.py
+++ b/elcid/__init__.py
@@ -31,8 +31,11 @@ class Application(application.OpalApplication):
         "General Consultation": "inline_forms/clinical_advice.html",
     }
 
-    menuitems = [
-        dict(
-            href='/pathway/#/add_patient', display='Add Patient', icon='fa fa-plus',
-            activepattern='/pathway/#/add_patient'),
-    ]
+    @classmethod
+    def get_menu_items(klass, user=None):
+        items = application.OpalApplication.get_menu_items(user=user)
+        items.append(
+            dict(
+                href='/pathway/#/add_patient', display='Add Patient', icon='fa fa-plus',
+                activepattern='/pathway/#/add_patient'))
+        return items


### PR DESCRIPTION
There's an open question remaining about what Opal version we want elCID RFH to target - e.g. 8.1 or 8.2... 

This syntax works for both but spits out an error in 8.2 so we can convert to MenuItems once we actually upgrade our requirements.