### PR TITLE
Format ints as ints because it's confusing not to.

### DIFF
--- a/elcid/assets/js/elcid/directives.js
+++ b/elcid/assets/js/elcid/directives.js
@@ -36,6 +36,13 @@ directives.directive("observationGraph", function (toMomentFilter) {
         legend: {
           show: false
         },
+        tooltip: {
+            format: {
+                value: function(value, ratio, id){
+                    return value
+                }
+            }
+        },
         subchart: {
            show: true
         },


### PR DESCRIPTION
Look at the tooltip value on say C Reactive Protein results where they're a series of integers