### PR TITLE
314 update fields to use form api

### DIFF
--- a/elcid/templates/forms/antimicrobial_form.html
+++ b/elcid/templates/forms/antimicrobial_form.html
@@ -1,7 +1,8 @@
 {% load forms %}
-{% input label="Drug" model="editing.antimicrobial.drug" lookuplist="antimicrobial_list" %}
-{% datepicker label="Start date" model="editing.antimicrobial.start_date" %}
-{% datepicker label="End date" model="editing.antimicrobial.end_date" %}
-{% input label="Dose" model="editing.antimicrobial.dose" %}
-{% input label="Route" model="editing.antimicrobial.route" lookuplist="antimicrobial_route_list" %}
-{% input label="Frequency" model="editing.antimicrobial.frequency" lookuplist="antimicrobial_frequency_list" %}
+
+{% input  field="Antimicrobial.drug" %}
+{% datepicker  field="Antimicrobial.start_date" %}
+{% datepicker  field="Antimicrobial.end_date" %}
+{% input  field="Antimicrobial.dose" %}
+{% input  field="Antimicrobial.route" %}
+{% input  field="Antimicrobial.frequency" %}

--- a/elcid/templates/forms/imaging_form.html
+++ b/elcid/templates/forms/imaging_form.html
@@ -1,5 +1,6 @@
 {% load forms %}
-{% datepicker  label="Date" model="editing.imaging.date"  %}
-{% input  label="Imaging Type" model="editing.imaging.imaging_type" lookuplist="imagingtypes_list" %}
-{% input  label="Site" model="editing.imaging.site"  %}
-{% textarea  label="Details" model="editing.imaging.details"  %}
+
+{% datepicker  field="Imaging.date"  %}
+{% input  field="Imaging.imaging_type" %}
+{% input  field="Imaging.site"  %}
+{% textarea  field="Imaging.details"  %}

--- a/elcid/templates/forms/line_form.html
+++ b/elcid/templates/forms/line_form.html
@@ -1,16 +1,14 @@
 {% load forms %}
-{% select label="Line Type" model="editing.line.line_type" lookuplist="line_type_list" %}
-{% checkbox label="Button Hole" model="editing.line.button_hole" %}
-{% checkbox label="Fistula" model="editing.line.fistula" %}
-{% checkbox label="Graft" model="editing.line.graft" %}
-
-{% radio label="" model="editing.line.tunnelled_or_temp" lookuplist="['Tunnelled', 'Temporary']" %}
-
-{% input label="Site" model="editing.line.site" lookuplist="line_site_list" %}
+{% select field="Line.line_type" %}
+{% checkbox field="Line.button_hole" %}
+{% checkbox field="Line.fistula" %}
+{% checkbox field="Line.graft" %}
+{% radio field="Line.tunnelled_or_temp" lookuplist="['Tunnelled', 'Temporary']" %}
+{% input field="Line.site" %}
 {% datetimepicker field="Line.insertion_datetime" %}
-{% input label="Inserted By" model="editing.line.inserted_by" %}
-{% input label="External Length When Inserted" model="editing.line.external_length" show="editing.line.line_type != 'Peripheral cannula'" unit="cm" %}
+{% input field="Line.inserted_by" %}
+{% input field="Line.external_length" show="editing.line.line_type != 'Peripheral cannula'" unit="cm" %}
 {% datetimepicker field="Line.removal_datetime" %}
-{% select label="Complications" model="editing.line.complications" lookuplist="line_complication_list" other=True %}
-{% select label="Removal Reason" model="editing.line.removal_reason" lookuplist="line_removal_reason_list" %}
+{% select field="Line.complications" other=True %}
+{% select field="Line.removal_reason" %}
 {% textarea label="Further Information" field="Line.special_instructions" %}

--- a/elcid/templates/forms/line_form.html
+++ b/elcid/templates/forms/line_form.html
@@ -1,14 +1,15 @@
 {% load forms %}
-{% select field="Line.line_type" %}
-{% checkbox field="Line.button_hole" %}
-{% checkbox field="Line.fistula" %}
-{% checkbox field="Line.graft" %}
-{% radio label="Tunnelled or Temporary" field="Line.tunnelled_or_temp" lookuplist="['Tunnelled', 'Temporary']" %}
-{% input label="Insertion Site" field="Line.site" %}
-{% datetimepicker date_label="Date of Insertion" time_label="Time of Insertion" field="Line.insertion_datetime" %}
-{% input field="Line.inserted_by" %}
-{% input field="Line.external_length" show="editing.line.line_type != 'Peripheral cannula'" unit="cm" %}
-{% datetimepicker date_label="Date of Removal" time_label="Time of Removal" field="Line.removal_datetime" %}
-{% select field="Line.complications" other=True %}
-{% select field="Line.removal_reason" %}
-{% textarea label="Further Information" field="Line.special_instructions" %}
+
+{% select  field="Line.line_type" %}
+{% checkbox  field="Line.button_hole" %}
+{% checkbox  field="Line.fistula" %}
+{% checkbox  field="Line.graft" %}
+{% radio  label="Tunnelled or Temporary" field="Line.tunnelled_or_temp" lookuplist="['Tunnelled', 'Temporary']" %}
+{% input  label="Insertion Site" field="Line.site" %}
+{% datetimepicker  date_label="Date of Insertion" time_label="Time of Insertion" field="Line.insertion_datetime" %}
+{% input  field="Line.inserted_by" %}
+{% input  field="Line.external_length" show="editing.line.line_type != 'Peripheral cannula'" unit="cm" %}
+{% datetimepicker  date_label="Date of Removal" time_label="Time of Removal" field="Line.removal_datetime" %}
+{% select  field="Line.complications" other=True %}
+{% select  field="Line.removal_reason" %}
+{% textarea  label="Further Information" field="Line.special_instructions" %}

--- a/elcid/templates/forms/line_form.html
+++ b/elcid/templates/forms/line_form.html
@@ -3,12 +3,12 @@
 {% checkbox field="Line.button_hole" %}
 {% checkbox field="Line.fistula" %}
 {% checkbox field="Line.graft" %}
-{% radio field="Line.tunnelled_or_temp" lookuplist="['Tunnelled', 'Temporary']" %}
-{% input field="Line.site" %}
-{% datetimepicker field="Line.insertion_datetime" %}
+{% radio label="Tunnelled or Temporary" field="Line.tunnelled_or_temp" lookuplist="['Tunnelled', 'Temporary']" %}
+{% input label="Insertion Site" field="Line.site" %}
+{% datetimepicker date_label="Date of Insertion" time_label="Time of Insertion" field="Line.insertion_datetime" %}
 {% input field="Line.inserted_by" %}
 {% input field="Line.external_length" show="editing.line.line_type != 'Peripheral cannula'" unit="cm" %}
-{% datetimepicker field="Line.removal_datetime" %}
+{% datetimepicker date_label="Date of Removal" time_label="Time of Removal" field="Line.removal_datetime" %}
 {% select field="Line.complications" other=True %}
 {% select field="Line.removal_reason" %}
 {% textarea label="Further Information" field="Line.special_instructions" %}

--- a/elcid/templates/forms/primary_diagnosis_form.html
+++ b/elcid/templates/forms/primary_diagnosis_form.html
@@ -1,2 +1,3 @@
 {% load forms %}
-{% select field="PrimaryDiagnosis.condition" %}
+
+{% select  field="PrimaryDiagnosis.condition" %}

--- a/elcid/templates/forms/primary_diagnosis_form.html
+++ b/elcid/templates/forms/primary_diagnosis_form.html
@@ -1,2 +1,2 @@
 {% load forms %}
-{% select label="Condition" model="editing.primary_diagnosis.condition" lookuplist="primarydiagnosiscondition_list" %}
+{% select field="PrimaryDiagnosis.condition" %}


### PR DESCRIPTION
closes #314 

note some tweaks to the default names of inputs for clarity, eg distinguishing between date/time of Insertion and date/time of removal (which are both on the same form)

![image](https://user-images.githubusercontent.com/2348385/33893514-79d060d4-df53-11e7-88ce-d5c5d64a9e60.png)

