### PR TITLE
added '.herokuapp.com' to allowed hosts list for demo/test deployments

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -40,6 +40,7 @@ ALLOWED_HOSTS = [
     'localhost',
     'ec2-52-16-175-249.eu-west-1.compute.amazonaws.com',
     '.openhealthcare.org.uk',
+    '.herokuapp.com',
     ]
 
 # Local time zone for this installation. Choices can be found here:


### PR DESCRIPTION
As per conversation with @davidmiller when pairing on a Heroku deployment branch, we noted that '.herokuapp.com' was not in the list of allowed hosts in elcid-rfh. We added it in that branch (which was temporary and only used for the deployment) but I've cherry-picked it into its own branch for a PR.