### PR TITLE
changes it to a select box, because our radio button formatting is a …

### DIFF
--- a/elcid/data/lookuplists/lookuplists.json
+++ b/elcid/data/lookuplists/lookuplists.json
@@ -2,23 +2,23 @@
   "referraltype": [
     {
       "synonyms": [],
-      "name": "Anti TNF treatment"
+      "name": "Primary care (GP)"
     },
     {
       "synonyms": [],
-      "name": "BCG vaccination"
+      "name": "Primary care (other)"
     },
     {
       "synonyms": [],
-      "name": "New entrant screening"
+      "name": "Secondary care"
     },
     {
       "synonyms": [],
-      "name": "Positive test"
+      "name": "TB Service"
     },
     {
       "synonyms": [],
-      "name": "Referred by GP"
+      "name": "Occupational Health"
     },
     {
       "synonyms": [],
@@ -26,15 +26,19 @@
     },
     {
       "synonyms": [],
-      "name": "Symptomatic"
+      "name": "A&E"
     },
     {
       "synonyms": [],
-      "name": "TB contact screening"
+      "name": "MXU"
     },
     {
       "synonyms": [],
-      "name": "Transferred"
+      "name": "Prixon screening"
+    },
+    {
+      "synonyms": [],
+      "name": "Port Health/HPA"
     }
   ],
   "line_removal_reason": [

--- a/elcid/templates/forms/referral_route_form.html
+++ b/elcid/templates/forms/referral_route_form.html
@@ -1,20 +1,3 @@
 {% load forms %}
 {% datepicker field="ReferralRoute.date_of_referral"  %}
-
-<div class="form-group">
-  <div class="col-sm-8 col-sm-push-3">
-    <div class="row text-center">
-      <label class="btn btn-default" ng-model="editing.referral_route.internal" btn-radio="true">Internal</label>
-      <label class="btn btn-default" ng-model="editing.referral_route.internal" btn-radio="false">External</label>
-    </div>
-  </div>
-</div>
-
-
-<div ng-show="editing.referral_route.internal">
-  {% input field="ReferralRoute.referral_team"  %}
-</div>
-<div ng-show="editing.referral_route.internal == false">
-  {% select field="ReferralRoute.referral_type"  %}
-  {% input field="ReferralRoute.referral_organisation"  %}
-</div>
+{% select field="ReferralRoute.referral_type"  %}

--- a/elcid/templates/records/referral_route.html
+++ b/elcid/templates/records/referral_route.html
@@ -1,9 +1,2 @@
 <span ng-show="item.date_of_referral">[[ item.date_of_referral  | shortDate ]]</span>
-<span ng-show="item.internal">
-  <span ng-show="item.referral_team">[[ item.referral_team ]] <br /></span>
-</span>
-
-<span ng-show="item.internal == false">
-  <span ng-show="item.referral_type">[[ item.referral_type ]] <br /></span>
-  <span ng-show="item.referral_route">[[ item.referral_organisation ]] <br /></span>
-</span>
+<span ng-show="item.referral_type">[[ item.referral_type ]] <br /></span>


### PR DESCRIPTION
…bit off for this amount of options. (also we'd like to use bootstrap buttons anyway). We need to delete existing lookup lists before deployment