### PR TITLE
Remove aliasing of python2.7 `unicode` to `u`

### DIFF
--- a/elcid/views.py
+++ b/elcid/views.py
@@ -16,7 +16,6 @@ from opal.core import application
 from elcid.forms import BulkCreateUsersForm
 
 app = application.get_app()
-u = unicode
 
 
 def temp_password():


### PR DESCRIPTION
This is not used, and prevents a python3 switch