### PR TITLE
Fixup: Don't use ancient exception handling syntax in middleware

### DIFF
--- a/elcid/middleware.py
+++ b/elcid/middleware.py
@@ -28,7 +28,7 @@ class LoggingMiddleware(object):
                 response.status_code, req_time, extra_log
             )
             logger.info(msg)
-        except Exception, e:
+        except Exception as e:
             logger.error("LoggingMiddleware Error: %s" % e)
 
         return response


### PR DESCRIPTION
Errors on Python 3, not a good idea in Python 2.7