### PR TITLE
Fixup: Don't require an Opal migration that doesn't exit.

### DIFF
--- a/apps/tb/migrations/0029_auto_20180815_1338.py
+++ b/apps/tb/migrations/0029_auto_20180815_1338.py
@@ -11,7 +11,7 @@ import opal.models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('opal', '0035_auto_20180815_1338'),
+        ('opal', '0035_auto_20180806_1150'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('tb', '0028_pregnancy'),
     ]


### PR DESCRIPTION
Whoops.