### PR TITLE
we should set dt.now when mocking as MagicMock() > 1 is not consisten…

### DIFF
--- a/elcid/test/test_fabric.py
+++ b/elcid/test/test_fabric.py
@@ -1366,6 +1366,7 @@ class DumpDatabaseTestCase(FabfileTestCase):
         self, print_fun, os, dt, time, local, is_load_running
     ):
         print "calling test_fails_first_time_works_the_next"
+        dt.datetime.now.return_value = datetime.datetime.now()
         is_load_running.side_effect = [True, None]
         os.path.return_value = True
         fabfile.dump_database(self.prod_env, "db_name", "backup_name")


### PR DESCRIPTION
…t in all versions of python/mock/envs