### PR TITLE
Remove the TB service as it has never been used and increases confusi…

### DIFF
--- a/elcid/patient_lists.py
+++ b/elcid/patient_lists.py
@@ -136,14 +136,6 @@ class Renal(RfhPatientList):
     schema = []
 
 
-class TB(RfhPatientList):
-    display_name = 'TB'
-    direct_add = True
-    tag = "tb"
-    template_name = 'episode_list.html'
-    schema = []
-
-
 class Sepsis(RfhPatientList):
     display_name = 'Sepsis Pathway'
     direct_add = True


### PR DESCRIPTION
…on refs #617

As noted at time of writing there are no episodes that have been added in TB ever. We are told that this is never used. We can remove it and the tag _should_ just vanish. In actual fact I'll check post release obviously.