### PR TITLE
Change it so that we don't receive emails unless the batch hasn't run…

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -219,8 +219,8 @@ load".format(time_ago.seconds)
                     )
                 )
 
-    one_hour_ago = timezone.now() - datetime.timedelta(seconds=60 * 60)
-    if models.BatchPatientLoad.objects.last().stopped < one_hour_ago:
+    three_hours_ago = timezone.now() - datetime.timedelta(seconds=60 * 180)
+    if models.BatchPatientLoad.objects.last().stopped < three_hours_ago:
         raise BatchLoadError("Last load has not run since {}".format(
             models.BatchPatientLoad.objects.last().stopped
         ))


### PR DESCRIPTION
… for three hours.

So in the error log of what we had this week. The batch at 2am finished at 2:05. The request for 3:00am didn't get sent for whatever reason until 3:07. 

It therefore concluded no batch had been run for over an hour. Every subsequent batch run didn't run until we manually logged in and forced it.

Why the cron job took so long to get to running the query is unknown.