### PR TITLE
reorders lab tests ordering

### DIFF
--- a/elcid/api.py
+++ b/elcid/api.py
@@ -340,7 +340,7 @@ class LabTestResultsView(LoginRequiredViewset):
             # ordered by most recent observations first please
             serialised_tests = sorted(
                 serialised_tests, key=lambda t: -serialization.deserialize_date(
-                    t["observation_date_range"][0]
+                    t["observation_date_range"][-1]
                 ).toordinal()
             )
 

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -333,16 +333,16 @@ class LabTestResultsView(LoginRequiredViewset):
             )
             serialised_tests.append(serialised_lab_test)
 
-            serialised_tests = sorted(
-                serialised_tests, key=itemgetter("lab_test_type")
-            )
+        serialised_tests = sorted(
+            serialised_tests, key=itemgetter("lab_test_type")
+        )
 
-            # ordered by most recent observations first please
-            serialised_tests = sorted(
-                serialised_tests, key=lambda t: -serialization.deserialize_date(
-                    t["observation_date_range"][-1]
-                ).toordinal()
-            )
+        # ordered by most recent observations first please
+        serialised_tests = sorted(
+            serialised_tests, key=lambda t: -serialization.deserialize_date(
+                t["observation_date_range"][-1]
+            ).toordinal()
+        )
 
         all_tags = list(_LAB_TEST_TAGS.keys())
 

--- a/elcid/templates/detail/result.html
+++ b/elcid/templates/detail/result.html
@@ -66,7 +66,7 @@
                   <div class="col-sm-2">
                     Range
                   </div>
-                  <div ng-repeat="obsDate in labTest.observation_date_range | limitTo:6 track by $index" class="col-sm-1">
+                  <div ng-repeat="obsDate in labTest.observation_date_range | limitTo:7 track by $index" class="col-sm-1">
                       [[ obsDate|displayDate ]]
                   </div>
                 </div>
@@ -83,7 +83,7 @@
                       -
                       [[ labTest.observation_metadata[observation_name].reference_range.max ]]
                     </div>
-                    <div ng-class="{'too-high': labTest.by_observations[observation_name][obsDate].observation_value > labTest.observation_metadata[observation_name].reference_range.max, 'too-low': labTest.by_observations[observation_name][obsDate].observation_value < labTest.observation_metadata[observation_name].reference_range.min}" ng-repeat="obsDate in labTest.observation_date_range | limitTo:6 track by $index" class="col-sm-1">
+                    <div ng-class="{'too-high': labTest.by_observations[observation_name][obsDate].observation_value > labTest.observation_metadata[observation_name].reference_range.max, 'too-low': labTest.by_observations[observation_name][obsDate].observation_value < labTest.observation_metadata[observation_name].reference_range.min}" ng-repeat="obsDate in labTest.observation_date_range | limitTo:7 track by $index" class="col-sm-1">
                       [[ labTest.by_observations[observation_name][obsDate].observation_value ]]
                     </div>
                   </div>


### PR DESCRIPTION
So this does...

Expose 7 tests per row, use limit on the client side, this is not perfect... but meant if we had 1-7th of October we were only showing 1-5 when we reversed the date order. This fixes that.

Fixes lab test order, lab tests are ordered by most recent observation then by lab test name. So it fixes that.

Fixes a bug in the existing implementation. There was an indentation bug, sorting was happening at the end of every single loop. This changes it sorting just happens once at the end.