### PR TITLE
Lab test cleanup 2

### DIFF
--- a/elcid/api.py
+++ b/elcid/api.py
@@ -147,9 +147,10 @@ class LabTestResultsView(LoginRequiredViewset):
         """
         result = defaultdict(dict)
         observations = sorted(
-            observations, key=lambda x: x.observation_datetime
+            observations,
+            key=lambda x: x.observation_datetime,
+            reverse=True
         )
-        observations.reverse()
         for observation in observations:
             obs_dict = result[observation.observation_name]
             obs_date = serialization.serialize_date(
@@ -226,7 +227,6 @@ class LabTestResultsView(LoginRequiredViewset):
             serialised_tests, key=get_latest_date, reverse=True
         )
         return serialised_tests
-
 
     @patient_from_pk
     def retrieve(self, request, patient):

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -221,7 +221,6 @@ class LabTestResultsView(LoginRequiredViewset):
                 api_name=slugify(lab_test_type),
                 observation_metadata=observation_metadata,
                 lab_test_type=lab_test_type,
-                observations=observations,
                 observation_date_range=observation_date_range,
                 # observation_time_series=observation_time_series,
                 by_observations=by_observations,

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -78,23 +78,6 @@ for tag, test_names in _LAB_TEST_TAGS.items():
         LAB_TEST_TAGS[test_name].append(tag)
 
 
-def extract_observation_value(observation_value):
-    """
-        if an observation is numeric, return it as a float
-        if its >12 return >12
-        else return None
-    """
-    regex = r'^[-0-9][0-9.]*$'
-    obs_result = observation_value.strip()
-    obs_result = obs_result.split("~")[0].strip("<").strip(">").strip()
-    if re.match(regex, obs_result):
-        return round(float(obs_result), 3)
-
-
-def get_observation_value(observation):
-    return extract_observation_value(observation["observation_value"])
-
-
 def clean_ref_range(ref_range):
     return ref_range.replace("]", "").replace("[", "").strip()
 
@@ -128,7 +111,7 @@ class LabTestResultsView(LoginRequiredViewset):
             "units": observation.units,
             "last_updated": serialization.serialize_datetime(observation.last_updated),
         }
-        obs_result = extract_observation_value(observation.observation_value)
+        obs_result = observation.value_numeric
         if obs_result:
             obs_dict["observation_value"] = obs_result
         else:
@@ -203,7 +186,6 @@ class LabTestResultsView(LoginRequiredViewset):
 
             observations = sorted(observations, key=lambda x: x["datetime_ordered"])
             observations = sorted(observations, key=lambda x: x["observation_name"])
-
 
             # observation_time_series = defaultdict(list)
             by_observations = defaultdict(list)

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -182,7 +182,7 @@ class LabTestResultsView(LoginRequiredViewset):
         form or long form
         """
         if lab_test_type in _ALWAYS_SHOW_AS_TABULAR:
-            return True
+            return False
 
         for observation in observations:
             if not observation.value_numeric:

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -187,11 +187,16 @@ class LabTestResultsView(LoginRequiredViewset):
                         long_form = True
 
                 if test_name not in by_observations:
+                    obs_for_test_name = {}
+                    for observation in observations:
+                        if observation["observation_name"] == test_name:
+                            # we don't serializer dictionary keys as part of
+                            # the serializer so we need to do it ourselves
+                            key = serialization.serialize_date(
+                                observation["observation_datetime"].date()
+                            )
+                            obs_for_test_name[key] = observation
 
-                    # we don't serializer dictionary keys as part of the serializer so we need to do it ourselves
-                    obs_for_test_name = {
-                        serialization.serialize_date(i["observation_datetime"].date()): i for i in observations if i["observation_name"] == test_name
-                    }
                     # if its all None's for a certain observation name lets skip it
                     # ie if WBC is all None, lets not waste the users' screen space
                     # sometimes they just have '-' so lets skip these too

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -89,23 +89,13 @@ class LabTestResultsView(LoginRequiredViewset):
     """
     base_name = 'lab_test_results_view'
 
-    def serialize_observation(self, observation):
-        obs_dict = {
-            "observation_name": observation.observation_name,
-            "observation_datetime": observation.observation_datetime,
-            "observation_number": observation.observation_number,
-            "reference_range": observation.cleaned_reference_range,
-            "units": observation.units,
-            "last_updated": serialization.serialize_datetime(observation.last_updated),
-            "datetime_ordered": observation.test.datetime_ordered,
-        }
+    def get_observation_value(self, observation):
         obs_result = observation.value_numeric
-        if obs_result:
-            obs_dict["observation_value"] = obs_result
-        else:
-            obs_dict["observation_value"] = observation.observation_value
 
-        return obs_dict
+        if obs_result:
+            return obs_result
+
+        return observation.observation_value
 
     def get_observations_by_lab_test(self, lab_tests):
         by_test = defaultdict(list)
@@ -194,7 +184,7 @@ class LabTestResultsView(LoginRequiredViewset):
                             key = serialization.serialize_date(
                                 observation.observation_datetime.date()
                             )
-                            obs_for_test_name[key] = self.serialize_observation(observation)
+                            obs_for_test_name[key] = self.get_observation_value(observation)
 
                     # if its all None's for a certain observation name lets skip it
                     # ie if WBC is all None, lets not waste the users' screen space

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -161,7 +161,6 @@ class LabTestResultsView(LoginRequiredViewset):
 
             # observation_time_series = defaultdict(list)
             by_observations = defaultdict(list)
-            timeseries = {}
 
             observation_metadata = {}
             observation_date_range = {
@@ -219,7 +218,6 @@ class LabTestResultsView(LoginRequiredViewset):
 
             serialised_lab_test = dict(
                 long_form=long_form,
-                timeseries=timeseries,
                 api_name=slugify(lab_test_type),
                 observation_metadata=observation_metadata,
                 lab_test_type=lab_test_type,

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -213,8 +213,7 @@ class LabTestResultsView(LoginRequiredViewset):
                     pass
                 else:
                     if isinstance(observation["observation_value"], str):
-                        if extract_observation_value(observation["observation_value"].strip(">").strip("<")) is None:
-                            long_form = True
+                        long_form = True
 
                 if test_name not in by_observations:
 

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -159,15 +159,18 @@ class LabTestResultsView(LoginRequiredViewset):
                 observation
             )
             if obs_date not in obs_dict:
-                obs_dict[obs_date] = obs_value
+                if observation.is_pending:
+                    obs_dict[obs_date] = "Pending"
+                else:
+                    obs_dict[obs_date] = obs_value
             else:
-                if obs_dict[obs_date].is_pending:
+                if obs_dict[obs_date] == "Pending":
                     obs_dict[obs_date] = obs_value
 
         return result
 
     def get_date_range(self, observations):
-        observation_date_range = set()
+        observation_date_range = set()  
 
         for observation in observations:
             observation_date_range.add(observation.observation_datetime.date())

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -161,8 +161,7 @@ class LabTestResultsView(LoginRequiredViewset):
             if obs_date not in obs_dict:
                 obs_dict[obs_date] = obs_value
             else:
-                current_obs_value = obs_dict[obs_date].observation_value
-                if current_obs_value.lower() == "pending":
+                if obs_dict[obs_date].is_pending:
                     obs_dict[obs_date] = obs_value
 
         return result
@@ -184,7 +183,7 @@ class LabTestResultsView(LoginRequiredViewset):
 
         for observation in observations:
             if not observation.value_numeric:
-                if not observation.observation_value.lower() == "pending":
+                if not observation.is_pending:
                     return True
         return False
 

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -129,7 +129,7 @@ class LabTestResultsView(LoginRequiredViewset):
         else:
             return observation_value is None
 
-    def get_qs(self, patient):
+    def get_last_365_days(self, patient):
         to_ignore = ['UNPROCESSED SAMPLE COMT', 'COMMENT', 'SAMPLE COMMENT']
         a_year_ago = datetime.date.today() - datetime.timedelta(365)
         lab_tests = patient.lab_tests.all()
@@ -142,7 +142,7 @@ class LabTestResultsView(LoginRequiredViewset):
     def get_observations_by_type_and_date_str(self, observations):
         """
         Returns a dict of observation name -> date -> observation
-        We choose the most recent date for the datetime unless the most
+        We choose the most recent datetime for the date unless the most
         recent is 'Pending'
         """
         result = defaultdict(dict)
@@ -206,7 +206,7 @@ class LabTestResultsView(LoginRequiredViewset):
 
         # so what I want to return is all observations to lab test desplay
         # name with the lab test properties on the observation
-        lab_tests = self.get_qs(patient)
+        lab_tests = self.get_last_365_days(patient)
         by_test = self.get_observations_by_lab_test(lab_tests)
         serialised_tests = []
 

--- a/elcid/assets/js/elcid/controllers/result_view.js
+++ b/elcid/assets/js/elcid/controllers/result_view.js
@@ -13,7 +13,7 @@ angular.module('opal.controllers').controller('ResultView', function(
       this.parseFloat = parseFloat;
 
       this.splitObservation = function(observation){
-        return observation.observation_value.split('~');
+        return observation.split('~');
       }
 
       this.isNumber = _.isNumber;
@@ -23,11 +23,11 @@ angular.module('opal.controllers').controller('ResultView', function(
           return false;
         }
 
-        if(_.isNumber(observation.observation_value)){
+        if(_.isNumber(observation)){
           return true;
         }
 
-        return observation.observation_value.replace('-', '').trim().length;
+        return observation.replace('-', '').trim().length;
       }
 
 
@@ -94,9 +94,8 @@ angular.module('opal.controllers').controller('ResultView', function(
         if(!nextObservation){
           return 0;
         }
-
-        var mostRecent = recentObservation.observation_value;
-        var nextRecent = nextObservation.observation_value;
+        var mostRecent = recentObservation;
+        var nextRecent = nextObservation;
 
         if(isNaN(mostRecent) || isNaN(nextRecent)){
           return 0

--- a/elcid/templates/detail/result.html
+++ b/elcid/templates/detail/result.html
@@ -32,7 +32,7 @@
                 <h5 class="inline">[[ labTest.lab_test_type ]] <span ng-show="labTest.observation_date_range.length === 1">- [[ labTest.observation_date_range[0]|displayDate ]]</span></h5> {% if request.user.is_superuser %}<a class="text-muted" href="/intrahospital_api/raw/results/[[ patient.demographics[0].hospital_number ]]/test/[[ labTest.lab_test_type ]]">&nbsp;view upstream {% icon "fa fa-code-fork" %}</a>{% endif %}
               </div>
             </div>
-            <div ng-show="labTest.observations.length">
+            <div ng-show="labTest.observation_date_range.length">
               <div ng-if="labTest.long_form">
                 <div class="row lab-test-row content-offset-below-10" ng-repeat="obsDate in labTest.observation_date_range track by $index" class="row">
                   <div class="col-sm-3">

--- a/elcid/templates/detail/result.html
+++ b/elcid/templates/detail/result.html
@@ -46,10 +46,10 @@
                         [[ observation_name ]]
                       </div>
                       <div class="col-md-9">
-                        <p ng-if="resultView.isNumber(labTest.by_observations[observation_name][obsDate].observation_value)">
-                          [[ labTest.by_observations[observation_name][obsDate].observation_value ]]
+                        <p ng-if="resultView.isNumber(labTest.by_observations[observation_name][obsDate])">
+                          [[ labTest.by_observations[observation_name][obsDate] ]]
                         </p>
-                        <span ng-if="!resultView.isNumber(labTest.by_observations[observation_name][obsDate].observation_value)">
+                        <span ng-if="!resultView.isNumber(labTest.by_observations[observation_name][obsDate])">
                           <p class="tilde-replacement-paragraph" ng-repeat="par_obs in resultView.splitObservation(labTest.by_observations[observation_name][obsDate]) track by $index">
                             [[ par_obs ]]
                           </p>
@@ -83,8 +83,8 @@
                       -
                       [[ labTest.observation_metadata[observation_name].reference_range.max ]]
                     </div>
-                    <div ng-class="{'too-high': labTest.by_observations[observation_name][obsDate].observation_value > labTest.observation_metadata[observation_name].reference_range.max, 'too-low': labTest.by_observations[observation_name][obsDate].observation_value < labTest.observation_metadata[observation_name].reference_range.min}" ng-repeat="obsDate in labTest.observation_date_range | limitTo:7 track by $index" class="col-sm-1">
-                      [[ labTest.by_observations[observation_name][obsDate].observation_value ]]
+                    <div ng-class="{'too-high': labTest.by_observations[observation_name][obsDate] > labTest.observation_metadata[observation_name].reference_range.max, 'too-low': labTest.by_observations[observation_name][obsDate] < labTest.observation_metadata[observation_name].reference_range.min}" ng-repeat="obsDate in labTest.observation_date_range | limitTo:7 track by $index" class="col-sm-1">
+                      [[ labTest.by_observations[observation_name][obsDate] ]]
                     </div>
                   </div>
                   <div ng-show="resultView.isShownObservation(labTest, observation_name)" class="row">

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -6,18 +6,14 @@ import mock
 import datetime
 
 from opal.core.test import OpalTestCase
-from elcid import models as elcid_models
 from django.utils import timezone
 from django.test import override_settings
 from rest_framework.reverse import reverse
 
 from elcid import models as emodels
-from plugins.labtests.models import LabTest
-
 from elcid.api import (
     BloodCultureResultApi, UpstreamBloodCultureApi, LabTestResultsView
 )
-from elcid import api
 
 
 class LabTestResultsViewTestCase(OpalTestCase):

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -405,6 +405,67 @@ class IsLongFormTestCase(OpalTestCase):
         )
 
 
+class SortLabTestsDictsTestCase(OpalTestCase):
+    def setUp(self):
+        self.this_year = datetime.date.today().year
+        self.api = LabTestResultsView()
+
+    def test_ordering_with_long_form(self):
+        dict_1 = {
+            "lab_test_type": "Test 1",
+            "long_form": False,
+            "observation_date_range": [
+                "12/04/{}".format(self.this_year),
+                "13/04/{}".format(self.this_year),
+                "14/04/{}".format(self.this_year)
+            ]
+        }
+        dict_2 = {
+            "lab_test_type": "Test 2",
+            "long_form": True,
+            "observation_date_range": [
+                "16/04/{}".format(self.this_year),
+                "15/04/{}".format(self.this_year),
+                "14/04/{}".format(self.this_year)
+            ]
+        }
+        dict_3 = {
+            "lab_test_type": "Test 3",
+            "long_form": False,
+            "observation_date_range": [
+                "13/04/{}".format(self.this_year),
+                "14/04/{}".format(self.this_year),
+                "15/04/{}".format(self.this_year)
+            ]
+        }
+        self.assertEqual(
+            self.api.sort_lab_tests_dicts([dict_1, dict_2, dict_3]),
+            [dict_2, dict_3, dict_1]
+        )
+
+    def test_ordering_within_a_date(self):
+        dict_1 = {
+            "lab_test_type": "Test Z",
+            "long_form": False,
+            "observation_date_range": [
+                "16/04/{}".format(self.this_year),
+                "15/04/{}".format(self.this_year)
+            ]
+        }
+        dict_2 = {
+            "lab_test_type": "Test A",
+            "long_form": False,
+            "observation_date_range": [
+                "16/04/{}".format(self.this_year),
+                "15/04/{}".format(self.this_year)
+            ]
+        }
+        self.assertEqual(
+            self.api.sort_lab_tests_dicts([dict_1, dict_2]),
+            [dict_2, dict_1]
+        )
+
+
 class UpstreamBloodCultureApiTestCase(OpalTestCase):
     def setUp(self):
         self.api = UpstreamBloodCultureApi()

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -37,13 +37,12 @@ class LabTestResultsViewTestCase(OpalTestCase):
             kwargs=dict(pk=self.patient.id),
             request=request
         )
+        self.this_year = datetime.date.today().year
 
     def new_lab_test_and_observation_please(self):
-        this_year = datetime.date.today().year
-
         lt = self.patient.lab_tests.create(**{
             "clinical_info":  'testing',
-            "datetime_ordered": datetime.datetime(this_year, 6, 17, 4, 15, 10),
+            "datetime_ordered": datetime.datetime(self.this_year, 6, 17, 4, 15, 10),
             "lab_number": "11111",
             "site": u'^&        ^',
             "status": "Sucess",
@@ -52,8 +51,8 @@ class LabTestResultsViewTestCase(OpalTestCase):
         })
 
         obs = lt.observation_set.create(
-            last_updated=datetime.datetime(this_year, 6, 18, 4, 15, 10),
-            observation_datetime=datetime.datetime(this_year, 4, 15, 4, 15, 10),
+            last_updated=datetime.datetime(self.this_year, 6, 18, 4, 15, 10),
+            observation_datetime=datetime.datetime(self.this_year, 4, 15, 4, 15, 10),
             observation_number="12312",
             reference_range="3.5 - 11",
             units="g",
@@ -72,7 +71,7 @@ class LabTestResultsViewTestCase(OpalTestCase):
                 "by_observations": {
                     "Aerobic bottle culture": {
                         "15/04/2019": {
-                            "datetime_ordered": "17/06/2019 " "04:15:10",
+                            "datetime_ordered": "17/06/2019 04:15:10",
                             "last_updated": "18/06/2019 " "04:15:10",
                             "observation_datetime": "15/04/2019 " "04:15:10",
                             "observation_name": "Aerobic " "bottle " "culture",
@@ -126,8 +125,8 @@ class LabTestResultsViewTestCase(OpalTestCase):
                     "Aerobic bottle culture": {
                         "15/04/2019": {
                             "datetime_ordered": "17/06/2019 " "04:15:10",
-                            "last_updated": "18/06/2019 " "04:15:10",
-                            "observation_datetime": "15/04/2019 " "04:15:10",
+                            "last_updated": "18/06/2019 04:15:10",
+                            "observation_datetime": "15/04/2019 04:15:10",
                             "observation_name": "Aerobic " "bottle " "culture",
                             "observation_number": "12312",
                             "observation_value": 234.0,
@@ -135,9 +134,9 @@ class LabTestResultsViewTestCase(OpalTestCase):
                             "units": "g",
                         },
                         "16/04/2019": {
-                            "datetime_ordered": "18/06/2019 " "04:15:10",
-                            "last_updated": "19/06/2019 " "04:15:10",
-                            "observation_datetime": "16/04/2019 " "04:15:10",
+                            "datetime_ordered": "18/06/2019 04:15:10",
+                            "last_updated": "19/06/2019 04:15:10",
+                            "observation_datetime": "16/04/2019 04:15:10",
                             "observation_name": "Aerobic " "bottle " "culture",
                             "observation_number": "12312",
                             "observation_value": 233.0,

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -20,23 +20,6 @@ from elcid.api import (
 from elcid import api
 
 
-class ExtractObservationValueTestCase(OpalTestCase):
-    def test_extract_observation_value(self):
-        inputs_to_expected_results = (
-            ("<1", float(1),),
-            ("1>", float(1),),
-            (" 1 ", float(1),),
-            ("< 1", float(1),),
-            (" < 1", float(1),),
-            (".1 ", None),
-            ("0.1 ", 0.1),
-            ("1E", None),
-            ("'1'", None),
-        )
-        for input, expected in inputs_to_expected_results:
-            self.assertEqual(api.extract_observation_value(input), expected)
-
-
 class LabTestResultsViewTestCase(OpalTestCase):
     def setUp(self):
         self.api = LabTestResultsView()

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -91,7 +91,6 @@ class LabTestResultsViewTestCase(OpalTestCase):
                 },
                 "observation_names": ["Aerobic bottle culture"],
                 "tags": [],
-                "timeseries": {},
             }
         ]
         response = self.client.get(self.url).json()

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -70,21 +70,12 @@ class LabTestResultsViewTestCase(OpalTestCase):
                 "api_name": "anti-cv2-crmp-5-antibodies",
                 "by_observations": {
                     "Aerobic bottle culture": {
-                        "15/04/2019": {
-                            "datetime_ordered": "17/06/2019 04:15:10",
-                            "last_updated": "18/06/2019 " "04:15:10",
-                            "observation_datetime": "15/04/2019 " "04:15:10",
-                            "observation_name": "Aerobic " "bottle " "culture",
-                            "observation_number": "12312",
-                            "observation_value": 234.0,
-                            "reference_range": {"max": 11.0, "min": 3.5},
-                            "units": "g",
-                        }
+                        "15/04/{}".format(self.this_year): 234.0
                     }
                 },
                 "lab_test_type": "Anti-CV2 (CRMP-5) antibodies",
                 "long_form": False,
-                "observation_date_range": ["15/04/2019"],
+                "observation_date_range": ["15/04/{}".format(self.this_year)],
                 "observation_metadata": {
                     "Aerobic bottle culture": {
                         "api_name": "aerobic-bottle-culture",
@@ -123,33 +114,15 @@ class LabTestResultsViewTestCase(OpalTestCase):
                 "api_name": "anti-cv2-crmp-5-antibodies",
                 "by_observations": {
                     "Aerobic bottle culture": {
-                        "15/04/2019": {
-                            "datetime_ordered": "17/06/2019 " "04:15:10",
-                            "last_updated": "18/06/2019 04:15:10",
-                            "observation_datetime": "15/04/2019 04:15:10",
-                            "observation_name": "Aerobic " "bottle " "culture",
-                            "observation_number": "12312",
-                            "observation_value": 234.0,
-                            "reference_range": {"max": 11.0, "min": 3.5},
-                            "units": "g",
-                        },
-                        "16/04/2019": {
-                            "datetime_ordered": "18/06/2019 04:15:10",
-                            "last_updated": "19/06/2019 04:15:10",
-                            "observation_datetime": "16/04/2019 04:15:10",
-                            "observation_name": "Aerobic " "bottle " "culture",
-                            "observation_number": "12312",
-                            "observation_value": 233.0,
-                            "reference_range": {"max": 11.0, "min": 3.5},
-                            "units": "g",
-                        }
+                        "15/04/{}".format(self.this_year): 234.0,
+                        "16/04/{}".format(self.this_year): 233.0
                     }
                 },
                 "lab_test_type": "Anti-CV2 (CRMP-5) antibodies",
                 "long_form": False,
                 "observation_date_range": [
-                    "15/04/2019",
-                    "16/04/2019",
+                    "15/04/{}".format(self.this_year),
+                    "16/04/{}".format(self.this_year),
                 ],
                 "observation_metadata": {
                     "Aerobic bottle culture": {
@@ -189,33 +162,15 @@ class LabTestResultsViewTestCase(OpalTestCase):
                 "api_name": "anti-cv2-crmp-5-antibodies",
                 "by_observations": {
                     "Aerobic bottle culture": {
-                        "15/04/2019": {
-                            "datetime_ordered": "17/06/2019 " "04:15:10",
-                            "last_updated": "18/06/2019 " "04:15:10",
-                            "observation_datetime": "15/04/2019 " "04:15:10",
-                            "observation_name": "Aerobic " "bottle " "culture",
-                            "observation_number": "12312",
-                            "observation_value": 234.0,
-                            "reference_range": {"max": 11.0, "min": 3.5},
-                            "units": "g",
-                        },
-                        "16/04/2019": {
-                            "datetime_ordered": "18/06/2019 " "04:15:10",
-                            "last_updated": "19/06/2019 " "04:15:10",
-                            "observation_datetime": "16/04/2019 " "04:15:10",
-                            "observation_name": "Aerobic " "bottle " "culture",
-                            "observation_number": "12312",
-                            "observation_value": "Negative",
-                            "reference_range": {"max": 11.0, "min": 3.5},
-                            "units": "g",
-                        },
+                        "15/04/{}".format(self.this_year): 234.0,
+                        "16/04/{}".format(self.this_year): "Negative"
                     }
                 },
                 "lab_test_type": "Anti-CV2 (CRMP-5) antibodies",
                 "long_form": True,
                 "observation_date_range": [
-                    "16/04/2019",
-                    "15/04/2019",
+                    "16/04/{}".format(self.this_year),
+                    "15/04/{}".format(self.this_year),
                 ],
                 "observation_metadata": {
                     "Aerobic bottle culture": {

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -90,18 +90,6 @@ class LabTestResultsViewTestCase(OpalTestCase):
                     }
                 },
                 "observation_names": ["Aerobic bottle culture"],
-                "observations": [
-                    {
-                        "datetime_ordered": "17/06/2019 04:15:10",
-                        "last_updated": "18/06/2019 04:15:10",
-                        "observation_datetime": "15/04/2019 04:15:10",
-                        "observation_name": "Aerobic bottle culture",
-                        "observation_number": "12312",
-                        "observation_value": 234.0,
-                        "reference_range": {"max": 11.0, "min": 3.5},
-                        "units": "g",
-                    }
-                ],
                 "tags": [],
                 "timeseries": {},
             }

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -420,30 +420,6 @@ class DemographicsSearchTestCase(OpalTestCase):
         )
 
 
-class GetReferenceRangeTestCase(OpalTestCase):
-    def test_clean_ref_range(self):
-        self.assertEqual(
-            api.get_reference_range("[ 2 - 3 ]"),
-            dict(min="2", max="3")
-        )
-
-    def test_return_none_if_only_dash(self):
-        self.assertIsNone(
-            api.get_reference_range(" - ")
-        )
-
-    def test_return_none_if_more_than_one_dash(self):
-        self.assertIsNone(
-            api.get_reference_range("else -something - or")
-        )
-
-    def test_return_stripped_max_min(self):
-        self.assertEqual(
-            api.get_reference_range("2-3"),
-            dict(min="2", max="3")
-        )
-
-
 class BloodCultureSetTestCase(OpalTestCase):
     def setUp(self):
         positive = datetime.date(2019, 5, 9)
@@ -908,31 +884,31 @@ class LabTestSummaryTestCase(OpalTestCase):
                 {
                     'latest_results': {'04/06/2019': 1.8, '05/06/2019': 1.8},
                     'name': 'WBC',
-                    'reference_range': {'max': '7.5', 'min': '1.7'},
+                    'reference_range': {'max': 7.5, 'min': 1.7},
                     'units': 'g/l'
                 },
                 {
                     'latest_results': {'04/06/2019': 1.0, '05/06/2019': 1.0},
                     'name': 'Lymphocytes',
-                    'reference_range': {'max': '4', 'min': '1'},
+                    'reference_range': {'max': 4, 'min': 1},
                     'units': '10'
                 },
                 {
                     'latest_results': {'04/06/2019': 2.0, '05/06/2019': 2.0},
                     'name': 'Neutrophils',
-                    'reference_range': {'max': '7.5', 'min': '1.7'},
+                    'reference_range': {'max': 7.5, 'min': 1.7},
                     'units': '10'
                 },
                 {
                     'latest_results': {'04/06/2019': 1.2, '05/06/2019': 1.2},
                     'name': 'INR',
-                    'reference_range': {'max': '1.12', 'min': '0.9'},
+                    'reference_range': {'max': 1.12, 'min': 0.9},
                     'units': 'Ratio'
                 },
                 {
                     'latest_results': {'04/06/2019': 1.0, '05/06/2019': 1.0},
                     'name': 'C Reactive Protein',
-                    'reference_range': {'max': '5', 'min': '0'},
+                    'reference_range': {'max': 5, 'min': 0},
                     'units': 'mg/L'
                 }
             ],
@@ -962,7 +938,7 @@ class LabTestSummaryTestCase(OpalTestCase):
                 {
                     'latest_results': {'04/06/2019': 1.3},
                     'name': 'INR',
-                    'reference_range': {'max': '1.12', 'min': '0.9'},
+                    'reference_range': {'max': 1.12, 'min': 0.9},
                     'units': 'Ratio'
                 }
             ],
@@ -1011,7 +987,7 @@ class LabTestSummaryTestCase(OpalTestCase):
                         },
                         'name': 'INR',
                         'reference_range': {
-                            'max': '1.12', 'min': '0.9'
+                            'max': 1.12, 'min': 0.9
                         },
                         'units': 'Ratio'
                     },
@@ -1025,7 +1001,7 @@ class LabTestSummaryTestCase(OpalTestCase):
                         },
                         'name': 'C Reactive Protein',
                         'reference_range': {
-                            'max': '5', 'min': '0'
+                            'max': 5, 'min': 0
                         },
                         'units': 'mg/L'
                     }

--- a/plugins/labtests/models.py
+++ b/plugins/labtests/models.py
@@ -156,6 +156,10 @@ class Observation(models.Model):
         return self.to_float(obs_result)
 
     @property
+    def is_pending(self):
+        return self.observation_value.lower() == "pending"
+
+    @property
     def cleaned_reference_range(self):
         """
         reference ranges appear of the form

--- a/plugins/labtests/models.py
+++ b/plugins/labtests/models.py
@@ -146,7 +146,7 @@ class Observation(models.Model):
         If possible we clean this up and return a number
         otherwise return None
         """
-        regex = r'^[-0-9][0-9.]*$'
+        regex = r'^[-+]?[0-9]+(\.[0-9]+)?$'
         obs_result = self.observation_value.strip()
         obs_result = obs_result.split("~")[0].strip("<").strip(">").strip()
         if re.match(regex, obs_result):

--- a/plugins/labtests/models.py
+++ b/plugins/labtests/models.py
@@ -168,22 +168,22 @@ class Observation(models.Model):
         For the moment we will now pass < 17
         """
         reference_range = self.reference_range.replace("]", "").replace("[", "")
-        reference_range = reference_range.strip()
-        if reference_range == "" or reference_range == "-":
+        regex = r"\s*([-+]?[0-9]+(\.[0-9]+)?)\s*-\s*([-+]?[0-9]+(\.[0-9]+)?)\s*?"
+        matches = re.search(regex, reference_range)
+        if not matches:
             return
 
-        min_max_range = [
-            self.to_float(i.strip()) for i in reference_range.split("-")
-        ]
-        # remove Nones
-        min_max_range = [i for i in min_max_range if i is not None]
+        groups = matches.groups()
 
-        if not len(min_max_range) == 2:
+        min_val = groups[0]
+        max_val = groups[2]
+
+        if min_val is None or max_val is None:
             return
 
         return {
-            "min": min_max_range[0],
-            "max": min_max_range[1]
+            "min": self.to_float(min_val),
+            "max": self.to_float(max_val)
         }
 
     def create(self, observation_dict):

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -189,7 +189,6 @@ class LabTestTestCase(OpalTestCase):
 
 class ObservationTestCase(OpalTestCase):
     def test_value_numeric(self):
-        patient, _ = self.new_patient_and_episode_please()
         observation = models.Observation()
 
         inputs_to_expected_results = (
@@ -210,7 +209,6 @@ class ObservationTestCase(OpalTestCase):
             self.assertEqual(observation.value_numeric, expected)
 
     def test_cleaned_reference_range(self):
-        patient, _ = self.new_patient_and_episode_please()
         observation = models.Observation()
 
         inputs_to_expected_results = (
@@ -229,3 +227,4 @@ class ObservationTestCase(OpalTestCase):
             if expected:
                 expected = {"min": expected[0], "max": expected[1]}
             self.assertEqual(observation.cleaned_reference_range, expected)
+

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -216,6 +216,9 @@ class ObservationTestCase(OpalTestCase):
         inputs_to_expected_results = (
             ("1.5 - 4", (1.5, 4,)),
             ('0 - 129', (0, 129,)),
+            ('-2 - 3', (-2, 3,)),
+            ('-5 - -2', (-5, -2,)),
+            ('-5 --2', (-5, -2,)),
             ("[      < 17     ]", None),
             ("1-6", (1, 6)),
             (" -   ", None),

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -228,3 +228,12 @@ class ObservationTestCase(OpalTestCase):
                 expected = {"min": expected[0], "max": expected[1]}
             self.assertEqual(observation.cleaned_reference_range, expected)
 
+    def test_is_pending_true(self):
+        observation = models.Observation()
+        observation.observation_value = 'Pending'
+        self.assertTrue(observation.is_pending)
+
+    def test_is_pending_false(self):
+        observation = models.Observation()
+        observation.observation_value = 'Not pending'
+        self.assertFalse(observation.is_pending)

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -203,6 +203,7 @@ class ObservationTestCase(OpalTestCase):
             ("0.1 ", 0.1),
             ("1E", None),
             ("'1'", None),
+            ("21.06.2019", None)
         )
         for input_value, expected in inputs_to_expected_results:
             observation.observation_value = input_value

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -208,3 +208,21 @@ class ObservationTestCase(OpalTestCase):
         for input_value, expected in inputs_to_expected_results:
             observation.observation_value = input_value
             self.assertEqual(observation.value_numeric, expected)
+
+    def test_cleaned_reference_range(self):
+        patient, _ = self.new_patient_and_episode_please()
+        observation = models.Observation()
+
+        inputs_to_expected_results = (
+            ("1.5 - 4", (1.5, 4,)),
+            ('0 - 129', (0, 129,)),
+            ("[      < 17     ]", None),
+            ("1-6", (1, 6)),
+            (" -   ", None),
+            ("  ", None),
+        )
+        for input_value, expected in inputs_to_expected_results:
+            observation.reference_range = input_value
+            if expected:
+                expected = {"min": expected[0], "max": expected[1]}
+            self.assertEqual(observation.cleaned_reference_range, expected)


### PR DESCRIPTION
So this means we use the same method for both the lab test summary api end point and the results view end point. 

It also fixes the bug where observations of a form such as 22.08.2019 cause the lab tests to fail