### PR TITLE
Bump the log out duration to 35mins.

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -308,7 +308,7 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 # !!! TODO: Are these how we want to discover these ?
 OPAL_OPTIONS_MODULE = 'elcid.options'
 OPAL_BRAND_NAME = 'elCID Royal Free Hospital'
-OPAL_LOG_OUT_MINUTES = 15
+OPAL_LOG_OUT_MINUTES = 35
 OPAL_LOG_OUT_DURATION = OPAL_LOG_OUT_MINUTES*60*1000
 
 # Do we need this at all ?


### PR DESCRIPTION
Auto-save and < 35mins might be more optimal, but this will prevent people losing pages of work mid TB consult.