### PR TITLE
Presenting symptoms details is being used a lot, so adding significan…

### DIFF
--- a/apps/tb/templates/panels/symptoms.html
+++ b/apps/tb/templates/panels/symptoms.html
@@ -21,16 +21,11 @@
                         ([[ episode.lymph_node_swelling_site[0].site ]])
                     </span><span ng-show="!$last">,</span>
                     </span>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-md-12">
                     [[ item.duration ]]
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-12">
-                    [[ item.details ]]
+                <div markdown="details" class="col-md-12">
                 </div>
             </div>
         </li>


### PR DESCRIPTION
…t whitespace makes the output a lot more readable. Duration appended to the line above to make it clear its regarding the symptoms rather than the details