### PR TITLE
If there is no micro input icu round relation serialize an empty micr…

### DIFF
--- a/elcid/models.py
+++ b/elcid/models.py
@@ -397,7 +397,7 @@ class MicrobiologyInput(EpisodeSubrecord):
         if MicroInputICURoundRelation.objects.filter(microbiology_input_id=self.id).exists():
             result["micro_input_icu_round_relation"] = self.microinputicuroundrelation.to_dict(*args, **kwargs)
         else:
-            result["micro_input_icu_round_relation"] = {}
+            result["micro_input_icu_round_relation"] = MicroInputICURoundRelation().to_dict()
         return result
 
     def update_from_dict(self, data, *args, **kwargs):

--- a/elcid/test/test_models.py
+++ b/elcid/test/test_models.py
@@ -423,6 +423,15 @@ class MicrobiologyInputTestCase(OpalTestCase):
             as_dict["micro_input_icu_round_relation"]["icu_round"]["sofa_score"]
         )
 
+    def test_to_dict_for_no_icu_round(self):
+        micro_input = emodels.MicrobiologyInput.objects.create(
+            episode=self.episode,
+            clinical_discussion="some discussion"
+        )
+        as_dict = micro_input.to_dict(None)
+        self.assertEqual(as_dict["micro_input_icu_round_relation"]["observation"], {})
+        self.assertEqual(as_dict["micro_input_icu_round_relation"]["icu_round"], {})
+
     def test_delete_with_icu_round(self):
         micro_input = emodels.MicrobiologyInput.objects.create(
             episode=self.episode,


### PR DESCRIPTION
…o icu relation so that it can be updated by the client if need be.

It was the case that if you had micro input that did was not ICU_ROUND but became ICU_ROUND error that it would throw an error because the editing dict was not correctly populated.

This changes it, now from the apis perspective there is always a micro_input_icu_round_relation.

From the database's perspective this is not the case and it is deleted if the reason for interaction changes. This means that we definitely reset the micro icu round if the icu round has changed.