### PR TITLE
Only select ICU handover patients who are not discharged

### DIFF
--- a/plugins/icu/loader.py
+++ b/plugins/icu/loader.py
@@ -15,7 +15,9 @@ from plugins.icu.episode_categories import ICUHandoverEpisode
 
 
 Q_GET_ICU_HANDOVER = """
-SELECT * FROM VIEW_ElCid_ITU_Handover
+SELECT *
+FROM VIEW_ElCid_ITU_Handover
+WHERE discharged = 'No'
 """
 
 


### PR DESCRIPTION
This allows us to change the upstream view in place without distorting our data, ahead of us then re-querying to source discharge dates.