### PR TITLE
Only copy over to the external demographics the fields on the externa…

### DIFF
--- a/intrahospital_api/update_demographics.py
+++ b/intrahospital_api/update_demographics.py
@@ -17,9 +17,27 @@ api = get_api()
 
 def update_external_demographics(
     external_demographics,
-    external_demographics_dict,
+    demographics_dict,
 ):
-    external_demographics_dict.pop('external_system')
+    external_demographics_fields = [
+        "hospital_number",
+        "nhs_number",
+        "surname",
+        "first_name",
+        "title",
+        "date_of_birth",
+        "sex",
+        "ethnicity",
+        "death_indicator",
+        "date_of_death"
+    ]
+
+    external_demographics_dict = {}
+    for field in external_demographics_fields:
+        result = demographics_dict.get(field)
+        if result:
+            external_demographics_dict[field] = result
+
     external_demographics.update_from_dict(
         external_demographics_dict, api.user, force=True
     )


### PR DESCRIPTION
…l demographics model.

The front end does not display other fields and after the reconciliation is clicked the db will later update the patients demographics.

As we bring in more patient fields some of which will be in other models it makes sense to decouple to external demographics from all the fields on the demographics model.