### PR TITLE
speed up the lab tests api load with select related and fewer queries

### DIFF
--- a/elcid/api.py
+++ b/elcid/api.py
@@ -297,10 +297,8 @@ class InfectionServiceTestSummaryApi(LoginRequiredViewset):
         that can be cast into a number
         """
         date_to_observation = {}
-        # this should never be the case, but
-        # we don't create the data so cater for it
-        qs = qs.exclude(observation_datetime=None)
-        for i in qs.order_by("-observation_datetime"):
+
+        for i in qs:
             if i.value_numeric is not None:
                 dt = i.observation_datetime
                 obs_date = dt.date()
@@ -321,6 +319,12 @@ class InfectionServiceTestSummaryApi(LoginRequiredViewset):
             test__test_name=lab_test_name
         ).filter(
             observation_name=observation_name
+        ).exclude(
+            observation_datetime=None
+        ).order_by(
+            "-observation_datetime"
+        ).select_related(
+            'test'
         )
 
     def get_PROCALCITONIN_Procalcitonin(self, observation):


### PR DESCRIPTION
Speed times for 100 patients at present...

<class 'elcid.api.InfectionServiceTestSummaryApi'> infection_service_summary_api-detail (4.00 seconds)
<class 'elcid.api.LabTestResultsView'> lab_test_results_view-detail (2.33 seconds)
<class 'plugins.covid.api.CovidServiceTestSummaryAPI'> covid_service_summary_api-detail (4.18 seconds)

with this change

<class 'elcid.api.InfectionServiceTestSummaryApi'> infection_service_summary_api-detail (3.35 seconds)
<class 'elcid.api.LabTestResultsView'> lab_test_results_view-detail (2.28 seconds)
<class 'plugins.covid.api.CovidServiceTestSummaryAPI'> covid_service_summary_api-detail (3.27 seconds)

Still annoying that the direct get all lab tests view is faster! however this does not include json serialization etc.

https://gist.github.com/fredkingham/551e85818063dd853715b1d8ea4aca6b

(My reasoning for this was to test out the effect of db indexes, db indexes made it slower)