### PR TITLE
Covid calculator flush

### DIFF
--- a/plugins/covid/calculator.py
+++ b/plugins/covid/calculator.py
@@ -5,6 +5,7 @@ import collections
 import datetime
 
 from django.utils import timezone
+from django.db import transaction
 
 from elcid.models import Demographics
 from plugins.labtests.models import LabTest
@@ -117,6 +118,7 @@ def calculate():
 
 
 @timing
+@transaction.atomic
 def refresh(covid_patients, covid_days):
     flush()
     models.CovidPatient.objects.bulk_create(covid_patients)


### PR DESCRIPTION
We had an issue where a user looked at the calculator dashboard while it was being calculated.

Previously this would throw an error because the dashboard did not exist.

The job ran once an hour and too just over 4 mins.

This changes it so all db deletes/writes are done in a single function and that function is atomic.

The deletes/writes take 0.35 seconds, and the transaction means that the database will not be read in an inconsistent state.