### PR TITLE
Remove discharge summaries and make ipls fail

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -426,9 +426,6 @@ def _load_patient(patient, patient_load):
 
             load_appointments(patient)
             logger.info('Completed initial appointment load for {}'.format(patient.id))
-
-            load_dischargesummaries(patient)
-            logger.info('Completed initial discharge summary load for {}'.format(patient.id))
     except:
         patient_load.failed()
         raise

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -392,44 +392,43 @@ def sync_patient(patient):
     )
 
 
-@transaction.atomic
 def _load_patient(patient, patient_load):
     logger.info(
         "Started patient {} Initial Load {}".format(patient.id, patient_load.id)
     )
     try:
-        hospital_number = patient.demographics_set.first().hospital_number
+        with transaction.atomic():
+            hospital_number = patient.demographics_set.first().hospital_number
 
-        results = api.results_for_hospital_number(hospital_number)
-        logger.info(
-            "loaded results for patient {} {}".format(
-                patient.id, patient_load.id
+            results = api.results_for_hospital_number(hospital_number)
+            logger.info(
+                "loaded results for patient {} {}".format(
+                    patient.id, patient_load.id
+                )
             )
-        )
-        update_lab_tests.update_tests(patient, results)
-        logger.info(
-            "tests updated for {} {}".format(patient.id, patient_load.id)
-        )
-
-        update_demographics.update_patient_information(patient)
-        logger.info(
-            "patient information updated for {} {}".format(
-                patient.id, patient_load.id
+            update_lab_tests.update_tests(patient, results)
+            logger.info(
+                "tests updated for {} {}".format(patient.id, patient_load.id)
             )
-        )
 
-        load_imaging(patient)
-        logger.info('Completed initial imaging load for {}'.format(patient.id))
+            update_demographics.update_patient_information(patient)
+            logger.info(
+                "patient information updated for {} {}".format(
+                    patient.id, patient_load.id
+                )
+            )
 
-        load_encounters(patient)
-        logger.info('Completed initial encounter load for {}'.format(patient.id))
+            load_imaging(patient)
+            logger.info('Completed initial imaging load for {}'.format(patient.id))
 
-        load_appointments(patient)
-        logger.info('Completed initial appointment load for {}'.format(patient.id))
+            load_encounters(patient)
+            logger.info('Completed initial encounter load for {}'.format(patient.id))
 
-        load_dischargesummaries(patient)
-        logger.info('Completed initial discharge summary load for {}'.format(patient.id))
+            load_appointments(patient)
+            logger.info('Completed initial appointment load for {}'.format(patient.id))
 
+            load_dischargesummaries(patient)
+            logger.info('Completed initial discharge summary load for {}'.format(patient.id))
     except:
         patient_load.failed()
         raise

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -427,6 +427,7 @@ def _load_patient(patient, patient_load):
             load_appointments(patient)
             logger.info('Completed initial appointment load for {}'.format(patient.id))
     except:
+        logger.error(f"Unable to load patient {patient.id}")
         patient_load.failed()
         raise
     else:

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -101,37 +101,6 @@ class _InitialLoadTestCase(ApiTestCase):
                 call_args_list[1][0], ("running 2/2",)
             )
 
-    @override_settings(
-        INTRAHOSPITAL_API='intrahospital_api.apis.dev_api.DevApi'
-    )
-    def test_integration(self):
-        with mock.patch.object(loader.logger, "info"):
-            loader._initial_load()
-
-            self.assertIsNotNone(
-                self.patient_1.demographics_set.first().hospital_number
-            )
-
-            self.assertIsNotNone(
-                self.patient_2.demographics_set.first().hospital_number
-            )
-
-            self.assertEqual(
-                imodels.InitialPatientLoad.objects.first().patient.id,
-                self.patient_1.id
-            )
-            self.assertEqual(
-                imodels.InitialPatientLoad.objects.last().patient.id,
-                self.patient_2.id
-            )
-            upstream_patients = lab_test_models.LabTest.objects.values_list(
-                "patient_id", flat=True
-            ).distinct()
-            self.assertEqual(
-                set([self.patient_1.id, self.patient_2.id]),
-                set(upstream_patients)
-            )
-
 
 class GetBatchStartTime(ApiTestCase):
     def test_batch_load_first(self):


### PR DESCRIPTION
Sorry this looks bigger than it is because we move @transaction.atomic into a with block. This means that if an InitialPatientLoad fails it gets stored in the db as a failure.

It also added logger.error so that we get an email when it fails.

It removes the test case, this needs more work and potentially some debate about how we handle apis.

It also removes the discharge summary load for the time being.