### PR TITLE
Use the get_api in the loaders

### DIFF
--- a/intrahospital_api/apis/dev_api.py
+++ b/intrahospital_api/apis/dev_api.py
@@ -505,3 +505,6 @@ class DevApi(base_api.BaseApi):
 
     def data_deltas(self, some_datetime):
         return []
+
+    def execute_hospital_query(self, *args, **kwargs):
+        return []

--- a/intrahospital_api/writeback.py
+++ b/intrahospital_api/writeback.py
@@ -6,9 +6,10 @@ import datetime
 
 from django.conf import settings
 from django.template.loader import get_template
+from intrahospital_api import get_api
 
 from elcid.models import Demographics, MicrobiologyInput
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 from plugins.covid.lab import get_covid_result_ticker
 from plugins.icu.loader import get_upstream_mrns
 
@@ -86,7 +87,7 @@ def write_result_summary():
         (d, serialise_summary(d.patient)) for d in demographics
     ]
 
-    api = ProdAPI()
+    api = get_api()
 
     for demographic, summary_text in summaries:
         params = {
@@ -128,6 +129,6 @@ def write_advice_upstream(advice_id):
         'datetime_issued'         : advice.when
     }
 
-    api = ProdAPI()
+    api = get_api()
     if settings.WRITEBACK_ON:
         api.execute_hospital_insert(ADVICE_INSERT, params=params)

--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -6,7 +6,7 @@ import datetime
 from django.db.models import DateTimeField
 from django.utils import timezone
 
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 
 from plugins.admissions.models import Encounter
 from plugins.admissions import logger
@@ -62,7 +62,7 @@ def load_encounters(patient):
     """
     Load any upstream admission data we may not have for PATIENT
     """
-    api = ProdAPI()
+    api = get_api()
 
     demographic = patient.demographics()
 

--- a/plugins/appointments/loader.py
+++ b/plugins/appointments/loader.py
@@ -7,7 +7,7 @@ from django.db.models import DateTimeField
 from django.utils import timezone
 
 from elcid.models import Demographics
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 
 from plugins.appointments.models import Appointment
 from plugins.appointments import logger
@@ -101,7 +101,7 @@ def load_appointments(patient):
     """
     Load any upstream appointment data we may not have for PATIENT
     """
-    api = ProdAPI()
+    api = get_api()
 
     demographic = patient.demographics()
 

--- a/plugins/appointments/tests/test_loader.py
+++ b/plugins/appointments/tests/test_loader.py
@@ -154,7 +154,7 @@ class LoadAppointmentTestCase(OpalTestCase):
             'HL7_Message_ID'            : '4567',
         }
 
-        with mock.patch.object(loader, 'ProdAPI') as mock_api:
+        with mock.patch.object(loader, 'get_api') as mock_api:
             mock_api.return_value.execute_hospital_query.return_value = [appointment_data]
 
             loader.load_appointments(self.patient)
@@ -181,7 +181,7 @@ class LoadAppointmentTestCase(OpalTestCase):
             'HL7_Message_ID'            : '4567',
         }
 
-        with mock.patch.object(loader, 'ProdAPI') as mock_api:
+        with mock.patch.object(loader, 'get_api') as mock_api:
             mock_api.return_value.execute_hospital_query.return_value = [appointment_data]
 
             loader.load_appointments(self.patient)

--- a/plugins/covid/loader.py
+++ b/plugins/covid/loader.py
@@ -4,7 +4,7 @@ Loading Covid data from upstream
 from opal.models import Patient
 from elcid.models import Demographics
 from elcid.episode_categories import InfectionService
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 from intrahospital_api.loader import create_rfh_patient_from_hospital_number
 from plugins.appointments import loader as appointment_loader
 from plugins.covid.episode_categories import CovidEpisode
@@ -29,7 +29,7 @@ def pre_load_covid_patients():
     If any of these are not currently part of the elCID cohort,
     create these patients.
     """
-    api = ProdAPI()
+    api = get_api()
 
     patient_mrns = set()
 
@@ -50,7 +50,7 @@ def pre_load_covid_patients():
 
 
 def create_followup_episodes():
-    api = ProdAPI()
+    api = get_api()
     results = set()
     for appointment in constants.COVID_FOLLOWUP_APPOINTMENT_TYPES:
         results_for_type = api.execute_hospital_query(

--- a/plugins/covid/tests/test_loader.py
+++ b/plugins/covid/tests/test_loader.py
@@ -8,14 +8,14 @@ from elcid.episode_categories import InfectionService
 
 
 @mock.patch("plugins.covid.loader.create_rfh_patient_from_hospital_number")
-@mock.patch("plugins.covid.loader.ProdAPI")
+@mock.patch("plugins.covid.loader.get_api")
 class CreateFollowUpEpisodeTestCase(OpalTestCase):
     def test_create_patient_who_does_not_exist(
         self,
-        ProdAPI,
+        get_api,
         create_rfh_patient_from_hospital_number
     ):
-        ProdAPI.return_value.execute_hospital_query.return_value = [
+        get_api.return_value.execute_hospital_query.return_value = [
             {"vPatient_Number": "111"}
         ]
         loader.create_followup_episodes()
@@ -25,12 +25,12 @@ class CreateFollowUpEpisodeTestCase(OpalTestCase):
 
     def test_create_episode_which_does_not_exist(
         self,
-        ProdAPI,
+        get_api,
         create_rfh_patient_from_hospital_number
     ):
         patient, _ = self.new_patient_and_episode_please()
         patient.demographics_set.update(hospital_number="111")
-        ProdAPI.return_value.execute_hospital_query.return_value = [
+        get_api.return_value.execute_hospital_query.return_value = [
             {"vPatient_Number": "111"}
         ]
         loader.create_followup_episodes()
@@ -51,10 +51,10 @@ class CreateFollowUpEpisodeTestCase(OpalTestCase):
 
     def test_do_nothing_if_episode_exists(
         self,
-        ProdAPI,
+        get_api,
         create_rfh_patient_from_hospital_number
     ):
-        ProdAPI.return_value.execute_hospital_query.return_value = [
+        get_api.return_value.execute_hospital_query.return_value = [
             {"vPatient_Number": "111"}
         ]
         patient, episode = self.new_patient_and_episode_please()

--- a/plugins/dischargesummary/loader.py
+++ b/plugins/dischargesummary/loader.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.db.models import DateTimeField
 from django.utils import timezone
 
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 
 from plugins.dischargesummary import logger
 from plugins.dischargesummary.models import (
@@ -45,7 +45,7 @@ def load_dischargesummaries(patient):
     """
     Given a PATIENT load upstream discharge summary data and save it.
     """
-    api = ProdAPI()
+    api = get_api()
 
     demographic = patient.demographics()
 

--- a/plugins/handover/loader.py
+++ b/plugins/handover/loader.py
@@ -6,7 +6,7 @@ from opal.models import Patient
 
 from elcid.models import Demographics
 from elcid.episode_categories import InfectionService
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 from intrahospital_api.loader import create_rfh_patient_from_hospital_number
 
 from plugins.icu import logger
@@ -25,7 +25,7 @@ def get_upstream_data():
     """
     Fetch the upstream handover
     """
-    api = ProdAPI()
+    api = get_api()
 
     return api.execute_hospital_query(Q_GET_AMT_HANDOVER)
 
@@ -118,7 +118,7 @@ def sync_amt_handover():
 
     This function is called from a management command + cron job
     """
-    api = ProdAPI()
+    api = get_api()
 
     current_patients = api.execute_hospital_query(Q_GET_CURRENT)
 

--- a/plugins/icu/loader.py
+++ b/plugins/icu/loader.py
@@ -6,7 +6,7 @@ from opal.models import Patient
 
 from elcid.models import Demographics
 from elcid.episode_categories import InfectionService
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 from intrahospital_api.loader import create_rfh_patient_from_hospital_number
 
 from plugins.icu import logger
@@ -30,7 +30,7 @@ def get_upstream_data():
     """
     Fetch the upstream handover snapshot data
     """
-    api = ProdAPI()
+    api = get_api()
 
     return api.execute_hospital_query(Q_GET_ICU_HANDOVER)
 
@@ -40,7 +40,7 @@ def get_upstream_mrns():
     Return a list of MRNs of patients currently undischarged on
     the ICU Handover database
     """
-    api = ProdAPI()
+    api = get_api()
 
     return [p['Patient_MRN'] for p in api.execute_hospital_query(Q_GET_ICU_MRNS)]
 

--- a/plugins/imaging/loader.py
+++ b/plugins/imaging/loader.py
@@ -6,7 +6,7 @@ import datetime
 from django.db.models import DateTimeField
 from django.utils import timezone
 
-from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import get_api
 
 from plugins.imaging.models import Imaging, PatientImagingStatus
 from plugins.imaging import logger
@@ -25,8 +25,7 @@ def load_imaging(patient):
     """
     Given a PATIENT, load any upstream imaging reports we do not have
     """
-    api = ProdAPI()
-
+    api = get_api()
     demographic = patient.demographics()
 
     imaging_count = patient.imaging.count()


### PR DESCRIPTION
So this is how I initially envisioned the api would work, the idea being you could switch out the api to get realistic data for when you were in a dev enviroment.

I'm fully open to other options.

This fixes the unit tests and makes them work like the intrahospital_api.loader