### PR TITLE
We cannot rely on the insert date for encounters. When we sync a pati…

### DIFF
--- a/etc/conf_templates/cron_admission_load.jinja2
+++ b/etc/conf_templates/cron_admission_load.jinja2
@@ -1,1 +1,1 @@
-7 */12 * * * {{ unix_user }} {{ virtualenv }}/bin/python {{ project_dir }}/manage.py fetch_admissions >> /usr/lib/ohc/log/cron_synch.log 2>&1
+7 * * * * {{ unix_user }} {{ virtualenv }}/bin/python {{ project_dir }}/manage.py fetch_admissions >> /usr/lib/ohc/log/cron.log 2>&1

--- a/etc/conf_templates/cron_admission_load.jinja2
+++ b/etc/conf_templates/cron_admission_load.jinja2
@@ -1,1 +1,1 @@
-7 * * * * {{ unix_user }} {{ virtualenv }}/bin/python {{ project_dir }}/manage.py fetch_admissions >> /usr/lib/ohc/log/cron.log 2>&1
+7 */2 * * * {{ unix_user }} {{ virtualenv }}/bin/python {{ project_dir }}/manage.py fetch_admissions >> /usr/lib/ohc/log/cron.log 2>&1

--- a/fabfile.py
+++ b/fabfile.py
@@ -1059,7 +1059,7 @@ def _deploy(new_branch, backup_name=None, remove_existing=False):
     # write_cron_appointment_load(new_env)
     # write_cron_imaging_load(new_env)
     # write_cron_discharge_load(new_env)
-#    write_cron_admission_load(new_env)
+    write_cron_admission_load(new_env)
     write_cron_disk_check(new_env)
     write_cron_backup_size(new_env)
     write_cron_calculate_dashboard(new_env)

--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -118,7 +118,7 @@ def load_recent_encounters():
     """
     api = ProdAPI()
 
-    timestamp = datetime.datetime.now() - datetime.timedelta(days=2)
+    timestamp = datetime.datetime.now() - datetime.timedelta(days=1)
 
     encounters = api.execute_hospital_query(
         Q_GET_RECENT_ENCOUNTERS,

--- a/plugins/admissions/management/commands/fetch_admissions.py
+++ b/plugins/admissions/management/commands/fetch_admissions.py
@@ -12,17 +12,9 @@ from plugins.admissions import loader, logger
 class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
-        failure_count = 0
-        for patient in Patient.objects.all():
-            try:
-                loader.load_encounters(patient)
-            except Exception:
-                failure_count += 1
-
-        if failure_count:
-            msg = "Failed to load admissions for {} patients \n".format(
-                failure_count
-            )
-            msg += "Last exception \n{}".format(traceback.format_exc())
+        try:
+            loader.load_recent_encounters()
+        except Exception:
+            msg += "Loading encounters:  \n{}".format(traceback.format_exc())
             logger.error(msg)
         return

--- a/plugins/admissions/management/commands/fetch_admissions.py
+++ b/plugins/admissions/management/commands/fetch_admissions.py
@@ -1,19 +1,33 @@
 """
 Management command to fetch all encounters for our patients
 """
+import datetime
+import time
 import traceback
 
 from django.core.management import BaseCommand
+from django.utils import timezone
 from opal.models import Patient
 
-from plugins.admissions import loader, logger
+from plugins.monitoring.models import Fact
 
+from plugins.admissions import loader, logger, models
 
 class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         try:
+            t1 = time.time()
             loader.load_recent_encounters()
+            t2 = time.time()
+
+            when             = timezone.make_aware(datetime.datetime.fromtimestamp(t1))
+            minutes_taken    = int(int(t2-t1)/60)
+            total_encounters = models.Encounter.objects.all().count()
+
+            Fact(when=when, label='Encounter Load Minutes', value=minutes_taken).save()
+            Fact(when=when, label='Total Encounters', value=total_encounters).save()
+
         except Exception:
             msg += "Loading encounters:  \n{}".format(traceback.format_exc())
             logger.error(msg)

--- a/plugins/covid/templates/covid/partials/recent_positive_row.html
+++ b/plugins/covid/templates/covid/partials/recent_positive_row.html
@@ -27,7 +27,7 @@
   <td>
     <p>
       {{ patient.encounter.admit_datetime }}
-      {{ patient.encounter.ward }} {{ encounter.room }} {{ encounter.bed }}
+      {{ patient.encounter.ward }} {{ patient.encounter.room }} {{ patient.encounter.bed }}
     </p>
   </td>
   <td>


### PR DESCRIPTION
…ent, fetch all their encounters, but use the upstream ID to overwrite new entries.