### PR TITLE
opal migration 0038 deletes a bunch of models that we have moved over…

### DIFF
--- a/elcid/migrations/0001_initial.py
+++ b/elcid/migrations/0001_initial.py
@@ -14,6 +14,10 @@ class Migration(migrations.Migration):
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
+    run_before = [
+        ('opal', '0038_auto_20191206_1449'),
+    ]
+
     operations = [
         migrations.CreateModel(
             name='Allergies',

--- a/elcid/migrations/0017_auto_20180108_1614.py
+++ b/elcid/migrations/0017_auto_20180108_1614.py
@@ -13,6 +13,10 @@ class Migration(migrations.Migration):
         ('elcid', '0016_auto_20171212_1252'),
     ]
 
+    run_before = [
+        ('opal', '0038_auto_20191206_1449'),
+    ]
+
     operations = [
         migrations.AlterField(
             model_name='antimicrobial',

--- a/elcid/migrations/0052_auto_20200518_2059.py
+++ b/elcid/migrations/0052_auto_20200518_2059.py
@@ -89,6 +89,10 @@ class Migration(migrations.Migration):
         ('elcid', '0051_auto_20200518_1758'),
     ]
 
+    run_before = [
+        ('opal', '0038_auto_20191206_1449'),
+    ]
+
     operations = [
         migrations.RunPython(
             forwards, backwards

--- a/elcid/migrations/0053_auto_20200518_2104.py
+++ b/elcid/migrations/0053_auto_20200518_2104.py
@@ -69,6 +69,10 @@ class Migration(migrations.Migration):
         ('elcid', '0052_auto_20200518_2059'),
     ]
 
+    run_before = [
+        ('opal', '0038_auto_20191206_1449'),
+    ]
+
     operations = [
         migrations.RunPython(
             forwards, backwards

--- a/elcid/migrations/0055_auto_20200518_2112.py
+++ b/elcid/migrations/0055_auto_20200518_2112.py
@@ -66,6 +66,10 @@ class Migration(migrations.Migration):
         ('elcid', '0054_auto_20200518_2112'),
     ]
 
+    run_before = [
+        ('opal', '0038_auto_20191206_1449'),
+    ]
+
     operations = [
         migrations.RunPython(
             forwards, backwards


### PR DESCRIPTION
… to elcid. We use those models in manual migrations so make sure the manual migrations (in fact all migrations that refer those models) run before the opal migration that delets them