### PR TITLE
Change the lab to use prefetch related and to filter the observations…

### DIFF
--- a/plugins/covid/calculator.py
+++ b/plugins/covid/calculator.py
@@ -45,11 +45,11 @@ def calculate_daily_reports():
     coronavirus_tests = LabTest.objects.filter(
         test_name__in=lab.COVID_19_TEST_NAMES
     )
-    coronavirus_tests = coronavirus_tests.order_by('datetime_ordered')
+    coronavirus_tests = coronavirus_tests.order_by('datetime_ordered').prefetch_related(
+        'observation_set'
+    )
 
-    first_test_date = LabTest.objects.filter(
-        test_name__in=lab.COVID_19_TEST_NAMES).order_by(
-            'datetime_ordered').first().datetime_ordered.date()
+    first_test_date = coronavirus_tests[0].datetime_ordered.date()
 
     for test in coronavirus_tests:
         if test.patient_id in junk_patient_ids:


### PR DESCRIPTION
… in python. This is a lot faster

Old way...
plugins.covid.calculator.calculate ran in 1228.2609 sec

New way...
plugins.covid.calculator.calculate ran in  138.5832 sec

ie from ~20mins to ~2mins

(Also means working on it locally becomes a lot eaiser...).

Notably its functionally equivalent so the existing unit tests still cover it.