### PR TITLE
Bulk create speed up 1

### DIFF
--- a/intrahospital_api/management/commands/batch_load2.py
+++ b/intrahospital_api/management/commands/batch_load2.py
@@ -21,7 +21,6 @@ from plugins.monitoring.models import Fact
 def send_email(title, template_name, context):
     html_message = render_to_string(template_name, context)
     plain_message = strip_tags(html_message)
-    admin_emails = ", ".join([i[1] for i in settings.ADMINS])
     send_mail(
         title,
         plain_message,

--- a/intrahospital_api/management/commands/batch_load2.py
+++ b/intrahospital_api/management/commands/batch_load2.py
@@ -31,7 +31,7 @@ def send_email(title, template_name, context):
 
 def create_email(**kwargs):
     template_name = "email/table_email.html"
-    title = f"{settings.OPAL_BRAND_NAME} new results sync"
+    title = f"{settings.OPAL_BRAND_NAME} results sync"
     send_email(title, template_name, {"table_context": kwargs, "title": title})
 
 

--- a/intrahospital_api/management/commands/batch_load2.py
+++ b/intrahospital_api/management/commands/batch_load2.py
@@ -31,8 +31,7 @@ def send_email(title, template_name, context):
 
 def create_email(**kwargs):
     template_name = "email/table_email.html"
-    title = "elCID RFH Live new results sync"
-
+    title = f"{settings.OPAL_BRAND_NAME} new results sync"
     send_email(title, template_name, {"table_context": kwargs, "title": title})
 
 

--- a/intrahospital_api/management/commands/batch_load2.py
+++ b/intrahospital_api/management/commands/batch_load2.py
@@ -3,7 +3,6 @@ A management command that is run by a cron job
 """
 import datetime
 import time
-import json
 from django.db import transaction
 from django.conf import settings
 from django.core.management.base import BaseCommand

--- a/intrahospital_api/management/commands/batch_load2.py
+++ b/intrahospital_api/management/commands/batch_load2.py
@@ -72,7 +72,6 @@ class Command(BaseCommand):
             if not patient_demographics_set.exists():
                 continue # Not in our cohort
 
-            item['lab_tests'] = [i for i in item['lab_tests'] if i["test_name"] or i["external_identifier"]]
             update_patient(patient_demographics_set.first().patient,  item["lab_tests"])
 
 
@@ -116,3 +115,5 @@ class Command(BaseCommand):
             label='48hr Observations',
             value_int=kw['48hr_obs']
         ).save()
+
+

--- a/intrahospital_api/update_lab_tests.py
+++ b/intrahospital_api/update_lab_tests.py
@@ -15,11 +15,6 @@ def clean_lab_test_dicts(lab_test_dicts):
     for lab_test_dict in lab_test_dicts:
         if not lab_test_dict["test_name"] and not lab_test_dict["external_identifier"]:
             continue
-        obs = []
-        for observation in lab_test_dict["observations"]:
-            if any(v for i, v in observation.items() if not i == "last_updated"):
-                obs.append(observation)
-        lab_test_dict["observations"] = obs
         result.append(lab_test_dict)
     return result
 

--- a/intrahospital_api/update_lab_tests.py
+++ b/intrahospital_api/update_lab_tests.py
@@ -3,6 +3,25 @@ from intrahospital_api import get_api
 
 api = get_api()
 
+def clean_lab_test_dicts(lab_test_dicts):
+    """
+    If there is no test number or lab number (aka external_identifier)
+    skip it.
+
+    Exclude observations that only have an last_updated time stamp
+    """
+    result = []
+
+    for lab_test_dict in lab_test_dicts:
+        if not lab_test_dict["test_name"] and not lab_test_dict["external_identifier"]:
+            continue
+        obs = []
+        for observation in lab_test_dict["observations"]:
+            if any(v for i, v in observation.items() if not i == "last_updated"):
+                obs.append(observation)
+        lab_test_dict["observations"] = obs
+        result.append(lab_test_dict)
+    return result
 
 def update_tests(patient, lab_tests):
     """
@@ -10,6 +29,7 @@ def update_tests(patient, lab_tests):
     that need saving updates those that need
     updating.
     """
+    lab_tests = clean_lab_test_dicts(lab_tests)
     for lab_test in lab_tests:
         delete_and_create_lab_test(patient, lab_test)
 

--- a/intrahospital_api/update_lab_tests.py
+++ b/intrahospital_api/update_lab_tests.py
@@ -27,6 +27,6 @@ def delete_and_create_lab_test(patient, lab_test):
         patient=patient
     ).delete()
     test = lab_test_models.LabTest()
-    test.update_from_api_dict(patient, lab_test)
+    test.create_from_api_dict(patient, lab_test)
     return test
 

--- a/plugins/labtests/models.py
+++ b/plugins/labtests/models.py
@@ -198,8 +198,3 @@ class Observation(models.Model):
         for f in fields:
             setattr(obs, f, observation_dict.get(f))
         return obs
-
-    def create(self, observation_dict):
-        obs = self.__class__.translate_to_object(observation_dict)
-        obs.save()
-        return obs

--- a/plugins/labtests/models.py
+++ b/plugins/labtests/models.py
@@ -35,7 +35,7 @@ class LabTest(models.Model):
     class Meta:
         ordering = ['-datetime_ordered']
 
-    def update_from_api_dict(self, patient, data):
+    def create_from_api_dict(self, patient, data):
         """
             This is the updateFromDict of the the UpstreamLabTest
 
@@ -71,15 +71,12 @@ class LabTest(models.Model):
         self.site = data["site"]
         self.test_name = data["test_name"]
         self.save()
+        observations = []
         for obs_dict in data["observations"]:
-            obs = self.observation_set.filter(
-                observation_number=obs_dict["observation_number"]
-            )
-            if obs.exists():
-                obs.delete()
-
-            obs = self.observation_set.create()
-            obs.create(obs_dict)
+            observation =  Observation.translate_to_object(obs_dict)
+            observation.test = self
+            observations.append(observation)
+        Observation.objects.bulk_create(observations)
 
     @classmethod
     def get_relevant_tests(self, patient):
@@ -181,12 +178,14 @@ class Observation(models.Model):
             "max": self.to_float(max_val)
         }
 
-    def create(self, observation_dict):
-        self.last_updated = serialization.deserialize_datetime(
+    @classmethod
+    def translate_to_object(cls, observation_dict):
+        obs = cls()
+        obs.last_updated = serialization.deserialize_datetime(
             observation_dict["last_updated"]
         )
         if observation_dict["observation_datetime"]:
-            self.observation_datetime = serialization.deserialize_datetime(
+            obs.observation_datetime = serialization.deserialize_datetime(
                 observation_dict["observation_datetime"]
             )
         fields = [
@@ -197,6 +196,10 @@ class Observation(models.Model):
             "units"
         ]
         for f in fields:
-            setattr(self, f, observation_dict.get(f))
-        self.save()
-        return self
+            setattr(obs, f, observation_dict.get(f))
+        return obs
+
+    def create(self, observation_dict):
+        obs = self.__class__.translate_to_object(observation_dict)
+        obs.save()
+        return obs

--- a/plugins/labtests/models.py
+++ b/plugins/labtests/models.py
@@ -180,6 +180,10 @@ class Observation(models.Model):
 
     @classmethod
     def translate_to_object(cls, observation_dict):
+        """
+        Returns a new unsaved instance of an Observation with the values
+        from observation_dict (datetimes translated from strings into dates).
+        """
         obs = cls()
         obs.last_updated = serialization.deserialize_datetime(
             observation_dict["last_updated"]

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -135,54 +135,6 @@ class LabTestTestCase(OpalTestCase):
             obs.observation_name, "Aerobic bottle culture"
         )
 
-    def test_create_from_api_dict_replaces_observation(self):
-        lt = self.patient.lab_tests.create(**{
-            "clinical_info":  'testing',
-            "datetime_ordered": timezone.make_aware(datetime.datetime(2015, 6, 17, 4, 15, 10)),
-            "lab_number": "11111",
-            "site": u'^&        ^',
-            "status": "Sucess",
-            "test_code": "AN12",
-            "test_name": "Anti-CV2 (CRMP-5) antibodies",
-        })
-
-        lt.observation_set.create(
-            last_updated=timezone.make_aware(datetime.datetime(2015, 6, 18, 4, 15, 10)),
-            observation_datetime=timezone.make_aware(datetime.datetime(2015, 4, 15, 4, 15, 10)),
-            observation_number="12312",
-            reference_range="3.5 - 11",
-            units="g",
-            observation_value="234"
-        )
-
-        lt.create_from_api_dict(self.patient, self.api_dict)
-
-        obs = lt.observation_set.get()
-
-        # this should have changed
-        self.assertEqual(
-            obs.observation_value,
-            "123"
-        )
-
-        # the below stay the same
-        self.assertEqual(
-            obs.observation_name,
-            "Aerobic bottle culture"
-        )
-        self.assertEqual(
-            obs.observation_number,
-            "12312"
-        )
-        self.assertEqual(
-            obs.reference_range,
-            "3.5 - 11"
-        )
-        self.assertEqual(
-            obs.units,
-            "g"
-        )
-
     def test_patient_deletion_behaviour(self):
         self.create_lab_test()
         self.patient.delete()

--- a/plugins/labtests/tests/test_models.py
+++ b/plugins/labtests/tests/test_models.py
@@ -50,9 +50,9 @@ class LabTestTestCase(OpalTestCase):
         )
         return lt
 
-    def test_update_from_api_dict_simple(self):
+    def test_create_from_api_dict_simple(self):
         lt = models.LabTest()
-        lt.update_from_api_dict(self.patient, self.api_dict)
+        lt.create_from_api_dict(self.patient, self.api_dict)
         self.assertEqual(
             lt.patient, self.patient
         )
@@ -116,26 +116,26 @@ class LabTestTestCase(OpalTestCase):
             "123"
         )
 
-    def test_update_from_api_dict_datetime_ordered_is_none(self):
+    def test_create_from_api_dict_datetime_ordered_is_none(self):
         lt = models.LabTest()
         api_dict = copy.deepcopy(self.api_dict)
         api_dict["datetime_ordered"] = None
-        lt.update_from_api_dict(self.patient, api_dict)
+        lt.create_from_api_dict(self.patient, api_dict)
         self.assertIsNone(lt.datetime_ordered)
         self.assertEqual(lt.test_name, "Anti-CV2 (CRMP-5) antibodies")
 
-    def test_update_from_api_dict_observation_datetime_is_none(self):
+    def test_create_from_api_dict_observation_datetime_is_none(self):
         lt = models.LabTest()
         api_dict = copy.deepcopy(self.api_dict)
         api_dict["observations"][0]["observation_datetime"] = None
-        lt.update_from_api_dict(self.patient, api_dict)
+        lt.create_from_api_dict(self.patient, api_dict)
         obs = lt.observation_set.get()
         self.assertIsNone(obs.observation_datetime)
         self.assertEqual(
             obs.observation_name, "Aerobic bottle culture"
         )
 
-    def test_update_from_api_dict_replaces_observation(self):
+    def test_create_from_api_dict_replaces_observation(self):
         lt = self.patient.lab_tests.create(**{
             "clinical_info":  'testing',
             "datetime_ordered": timezone.make_aware(datetime.datetime(2015, 6, 17, 4, 15, 10)),
@@ -155,7 +155,7 @@ class LabTestTestCase(OpalTestCase):
             observation_value="234"
         )
 
-        lt.update_from_api_dict(self.patient, self.api_dict)
+        lt.create_from_api_dict(self.patient, self.api_dict)
 
         obs = lt.observation_set.get()
 


### PR DESCRIPTION
* Changes the creation of lab tests by the batch load to use bulk_create on the observations.
* Skip lab tests when we are not provided a hospital number.
* Skip lab tests when we are not provided either a lab number or a test name.