### PR TITLE
Removes the TB OBs from the Patient Detail screen

### DIFF
--- a/plugins/tb/templates/partials/tb_tests.html
+++ b/plugins/tb/templates/partials/tb_tests.html
@@ -18,7 +18,14 @@
         </div>
       </div>
       <div ng-repeat="culture in tb_tests.cultures">
-        <div ng-class="{'text-muted': !culture.positive, 'left-offset-10': !$first}" ng-repeat="culture_line in culture.text">
+        <div ng-class="{'text-muted': !culture.positive}">
+          [[ culture.title ]]
+          <div class="left-offset-10" ng-repeat="(obs_name, display_lines) in culture.by_obs_display track by $index">
+            <div ng-class="{'left-offset-10': !$first}" ng-repeat="display in display_lines track by $index">
+              [[ display ]]
+            </div>
+          </div>
+
           <div ng-class="{'left-offset-20': !$first && culture_line.indexOf('AFB Smear') !== 0 && culture_line.indexOf('TB: Culture Result') !== 0 && culture_line.indexOf('TB Ref. Lab. Culture result') !== 0}">
           [[ culture_line ]]
           </div>
@@ -38,7 +45,7 @@
         </div>
       </div>
       <div ng-repeat="pcr in tb_tests.pcrs">
-        <div ng-class="{'text-muted': !pcr.positive, 'left-offset-10': !$first}" ng-repeat="pcr_line in pcr.text">
+        <div ng-class="{'text-muted': !pcr.positive, 'left-offset-10': !$first}" ng-repeat="pcr_line in pcr.text track by $index">
           [[ pcr_line ]]
         </div>
       </div>

--- a/plugins/tb/views.py
+++ b/plugins/tb/views.py
@@ -742,3 +742,60 @@ class OutstandingActionsMDT(LoginRequiredMixin, TemplateView):
         ctx["date_to_rows"] = date_to_rows
         ctx["num_consultations"] = len(patient_consultations)
         return ctx
+
+
+class TBActivity(TemplateView):
+    @property
+    def start_date(self):
+        return datetime.date(2020, 1, 1)
+
+    @property
+    def end_date(self):
+        return datetime.date(2021, 1, 1)
+
+    @property
+    def weeks(self):
+        weeks = []
+        for i in range(51):
+            weeks.append(
+                self.start_date + i*7,
+                max([
+                    self.start_date + ((i+1)*7),
+                    self.end_date
+                ])
+            )
+        return weeks
+
+    def get_top_summary(self):
+        return {
+            "Number of patients": 0,
+            "Number of appointments": 0,
+            "Number of positive TB Test": 0
+        }
+
+    def patients_by_appointment_type(self):
+        return {
+            "Nurse appointments": 0,
+            "Doctor Appointments": 0,
+            "Telephone Appointments": 0,
+            "Other": 0
+        }
+
+    def patients_by_appointment_status(self):
+        return {
+
+        }
+
+    def new_patients_by_demographics(self):
+        return {}
+
+    def new_patients_by_number_of_appointments(self):
+        return {
+            (0-5),
+            (6-10),
+            ()
+        }
+
+    def get_context_data(self):
+        new_patients
+        pass


### PR DESCRIPTION
So this does....
1. Removes the old tb.lab as we don't use that.
2. Puts in the queries for positive/negative/resulted in the lab. These queries query plugins.labtests.models.Observation
3. Moves the TB Obs logic out of the patient detail page to make it easier to rethink these at a future date.