### PR TITLE
Admissions duplicate patients

### DIFF
--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -138,9 +138,15 @@ def load_excounters_since(timestamp):
         if patients:
             for patient in patients:
                 save_encounter(encounter, patient)
+                patient.patientencounterstatus_set.update(
+                    has_encounters=True
+                )
         else:
             patient = create_rfh_patient_from_hospital_number(mrn, InfectionService)
             save_encounter(encounter, patient)
+            patient.patientencounterstatus_set.update(
+                has_encounters=True
+            )
 
 
 def load_transfer_history():

--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -104,7 +104,7 @@ def load_encounters(patient):
             status.save()
 
 
-def load_recent_encounters():
+def load_excounters_since(timestamp):
     """
     Query upstream for all encounters updated in a recent period.
 
@@ -123,8 +123,6 @@ def load_recent_encounters():
     """
     from intrahospital_api.loader import create_rfh_patient_from_hospital_number
     api = ProdAPI()
-
-    timestamp = datetime.datetime.now() - datetime.timedelta(days=1)
 
     encounters = api.execute_hospital_query(
         Q_GET_RECENT_ENCOUNTERS,

--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -131,16 +131,15 @@ def load_recent_encounters():
         params={'timestamp': timestamp}
     )
     for encounter in encounters:
-        mrn = encounter['PID_3_MRN']
+        mrn = encounter['PID_3_MRN'].strip()
 
         if mrn == '':
             continue
 
-        if Demographics.objects.filter(hospital_number=mrn).exists():
-            patient = Patient.objects.filter(demographics__hospital_number=mrn).first()
-
-            save_encounter(encounter, patient)
-
+        patients = Patient.objects.filter(demographics__hospital_number=mrn)
+        if patients:
+            for patient in patients:
+                save_encounter(encounter, patient)
         else:
             patient = create_rfh_patient_from_hospital_number(mrn, InfectionService)
             save_encounter(encounter, patient)

--- a/plugins/admissions/management/commands/fetch_admissions.py
+++ b/plugins/admissions/management/commands/fetch_admissions.py
@@ -18,7 +18,8 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         try:
             t1 = time.time()
-            loader.load_recent_encounters()
+            timestamp = datetime.datetime.now() - datetime.timedelta(days=1)
+            loader.load_excounters_since(timestamp)
             t2 = time.time()
 
             when             = timezone.make_aware(datetime.datetime.fromtimestamp(t1))

--- a/plugins/admissions/tests/test_command_fetch.py
+++ b/plugins/admissions/tests/test_command_fetch.py
@@ -15,7 +15,7 @@ class CommandTestCase(OpalTestCase):
     def test_creates_facts(self):
         self.assertEqual(0, Fact.objects.all().count())
 
-        with mock.patch.object(fetch_admissions.loader, 'load_recent_encounters'):
+        with mock.patch.object(fetch_admissions.loader, 'load_excounters_since'):
             cmd = fetch_admissions.Command()
             cmd.handle()
             self.assertEqual(2, Fact.objects.all().count())


### PR DESCRIPTION
* If there are encounters for duplicate patients we should load the encounters in on both the patients, in keeping with the other loaders.

* Changes the load recent encounters method to be load encounters since. This is so if the upstream server connection fails for whatever reason we can manage the load in of the data.

* Make sure we update the has_encounter status for the patients we load in.

