### PR TITLE
Angular is inconsistent in when its rendering the name in the header,…

### DIFF
--- a/elcid/assets/js/elcid/directives.js
+++ b/elcid/assets/js/elcid/directives.js
@@ -127,8 +127,8 @@ directives.directive('fixedHeader', function(){
     restrict: 'A',
     link: function(scope, $elm, attrs) {
       var panelHeader = $(".panel-heading.patient-detail-heading");
+      var cnt = 0;
       var adjustHeights = function(){
-        // adjust when the panel body starts
         var panelHeaderHeight = panelHeader.height();
 
         // the nav bar collapses at small sizes, accomdate for this.
@@ -152,6 +152,10 @@ directives.directive('fixedHeader', function(){
         else{
           panelHeader.removeClass('shrunken');
         }
+        cnt += 1;
+        if(cnt > 20){
+          clearInterval(interval)
+        }
       }
       var shrinkHeader = function(){
         // when we're slightly down the page add the class
@@ -163,7 +167,10 @@ directives.directive('fixedHeader', function(){
         }
       }
 
-      setTimeout(adjustHeights, 0);
+      // Angular occassionally populates the header
+      // after the directive has loaded, so just
+      // keep at it for the firsrt 20 seconds
+      var interval = setInterval(adjustHeights, 100);
       $(window).scroll(shrinkHeader);
       $(window).resize(adjustHeights);
     }

--- a/elcid/assets/js/elcid/directives.js
+++ b/elcid/assets/js/elcid/directives.js
@@ -127,7 +127,7 @@ directives.directive('fixedHeader', function(){
     restrict: 'A',
     link: function(scope, $elm, attrs) {
       var panelHeader = $(".panel-heading.patient-detail-heading");
-      var cnt = 0;
+      var counter = 0;
       var adjustHeights = function(){
         var panelHeaderHeight = panelHeader.height();
 
@@ -152,8 +152,8 @@ directives.directive('fixedHeader', function(){
         else{
           panelHeader.removeClass('shrunken');
         }
-        cnt += 1;
-        if(cnt > 20){
+        counter += 1;
+        if(counter > 20){
           clearInterval(interval)
         }
       }


### PR DESCRIPTION
… because of this the fixed header was sometimes rendering wrong as it was incorrectly calculating the height of the header. This change means we repeatedly set the height of the header to make sure its right (the operation is cheap)