### PR TITLE
Remove these print statements as the fill up the logs but its unclear…

### DIFF
--- a/plugins/covid/management/commands/calculate_amt_dashboard.py
+++ b/plugins/covid/management/commands/calculate_amt_dashboard.py
@@ -34,8 +34,6 @@ class Command(BaseCommand):
 
             covid = take.filter(rota='COVID')
             non_covid = take.filter(rota='NON-COVID')
-            print(target)
-            print(take.count())
             CovidAcuteMedicalDashboardReportingDay(
                 date=target, patients_referred=take.count(),
                 covid=covid.count(), non_covid=non_covid.count()


### PR DESCRIPTION
… from the logs what's causing them

they fill up the logs with lists like but its unclear what's causing them

```
2020-04-01 00:00:00+00:00
12
2020-04-02 00:00:00+00:00
31
2020-04-03 00:00:00+00:00
32
```