### PR TITLE
Make sure we only calculate the patient detail header in its non shru…

### DIFF
--- a/elcid/assets/js/elcid/directives.js
+++ b/elcid/assets/js/elcid/directives.js
@@ -129,6 +129,9 @@ directives.directive('fixedHeader', function(){
       var panelHeader = $(".panel-heading.patient-detail-heading");
       var counter = 0;
       var adjustHeights = function(){
+        if(document.documentElement.scrollTop > 100){
+          return;
+        }
         var panelHeaderHeight = panelHeader.height();
 
         // the nav bar collapses at small sizes, accomdate for this.


### PR DESCRIPTION
…nken state

So the problem with recalculating while waiting for angular is if the patient scrolls down too quickly we calculate the header based on the shrunken header and it breaks. This fixes that.