### PR TITLE
Add in the missing dependency of the logger in admissions.models and …

### DIFF
--- a/plugins/admissions/models.py
+++ b/plugins/admissions/models.py
@@ -3,9 +3,8 @@ Models for the elCID admissions plugin
 """
 import datetime
 from django.db import models
-from django.utils.functional import cached_property
 from opal.models import Patient, PatientSubrecord
-
+from plugins.admissions import logger
 from plugins.admissions import constants
 
 


### PR DESCRIPTION
…removes the cached_property dependency as this is not used