### PR TITLE
Reject everything that is not heading to our expected address

### DIFF
--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -5,8 +5,7 @@ log_format timed_combined escape=json '$remote_addr - $remote_user [$time_local]
 
 server {
     listen 80;
-    server_name "";
-    server_name elcid-rfh-test.openhealthcare.org.uk;
+    server_name 192.168.21.202 192.168.21.203 elcid-rfh-test elcid-rfh elcid;
     access_log /usr/lib/ohc/log/nginx.log timed_combined;
 
     location /himunin {
@@ -25,7 +24,16 @@ server {
     }
 
     location /protected {
-         internal;
-         alias /;
+            internal;
+            alias /;
     }
-  }
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    location / {
+        return 403;
+    }
+}


### PR DESCRIPTION
So we want to make sure that if people are pen testing our server we reject their requests and don't get emails about it.

The below works for the following test cases on test
`curl -i elcid-rfh-test` get's me the 302 you'd expect

`curl -i http://elcid-rfh-test-1 --resolve 'elcid-rfh-test-1:80:192.168.21.203'` now returns a 403
