### PR TITLE
This changes it so we ignore transfer histories with no mrn

### DIFF
--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -257,7 +257,7 @@ def clean_transfer_history_rows(rows):
     Sometimes the duplicates updated timestamps are the same
     so we need to look at created and updated.
     """
-    rows = [i for i in rows if i['LOCAL_PATIENT_IDENTIFIER'].strip()]
+    rows = [i for i in rows if i['LOCAL_PATIENT_IDENTIFIER'] and i['LOCAL_PATIENT_IDENTIFIER'].strip()]
     rows = sorted(rows, key=lambda x: (x['UPDATED_DATE'], x['CREATED_DATE']))
     upstream_rows = {}
     # because we ordered by updated, created, this will remove earlier created updated


### PR DESCRIPTION
There exist transfer histories with a null local patient identifier.

Prior to this change the whole mgmt command fell over for these rows.