### PR TITLE
Zero fixes for loaders where the upstream system does not use zero prefixes

### DIFF
--- a/intrahospital_api/update_demographics.py
+++ b/intrahospital_api/update_demographics.py
@@ -250,6 +250,11 @@ def update_patient_information(patient):
     demographics = patient.demographics_set.all()[0]
     hospital_number = demographics.hospital_number
 
+    # We have Patients that have leading 0s in their
+    # hospital numbers. The CRS master file
+    # have these zeros stripped out so remove them.
+    hospital_number = hospital_number.lstrip('0')
+
     if not hospital_number:
         msg = " ".join([
             f"Patient {patient.id} has not hospital number",
@@ -261,15 +266,6 @@ def update_patient_information(patient):
     upstream_patient_information = api.patient_masterfile(
         hospital_number
     )
-
-    if upstream_patient_information is None:
-        # If the hn begins with leading 0(s)
-        # the data is sometimes empty in the CRS_* fields.
-        # So if we cannot find rows with 0 prefixes
-        # remove the prefix
-        upstream_patient_information = api.patient_masterfile(
-            hospital_number.lstrip("0")
-        )
 
     # this should never really happen but has..
     # It happens in the case of a patient who has previously

--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -13,7 +13,7 @@ from opal.models import Patient
 from elcid.episode_categories import InfectionService
 from elcid.models import Demographics
 from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
-from intrahospital_api.loader import hospital_numbers_to_patients
+
 
 from plugins.admissions.models import Encounter, PatientEncounterStatus, TransferHistory, BedStatus
 from plugins.admissions import logger
@@ -236,7 +236,9 @@ def create_patients(mrns):
     This is done outside a transaction to handle any race conditions
     that may exist with the transactions it spawns.
     """
-    from intrahospital_api.loader import create_rfh_patient_from_hospital_number
+    from intrahospital_api.loader import (
+        create_rfh_patient_from_hospital_number, hospital_numbers_to_patients
+    )
     existing_mrns = set(Demographics.objects.filter(hospital_number__in=mrns).values_list(
         'hospital_number', flat=True
     ))
@@ -333,7 +335,9 @@ def load_bed_status():
     """
     Flush and re-load the upstream current_bed_status
     """
-    from intrahospital_api.loader import create_rfh_patient_from_hospital_number
+    from intrahospital_api.loader import (
+        create_rfh_patient_from_hospital_number, hospital_numbers_to_patients
+    )
 
     api = ProdAPI()
 

--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -342,28 +342,31 @@ def load_bed_status():
     )
 
     with transaction.atomic():
+        hns = [
+            i["Local_Patient_Identifier"] for i in status if i["Local_Patient_Identifier"]
+        ]
+        hn_to_patient = hospital_numbers_to_patients(hns)
+        for hn in hns:
+            if hn not in hn_to_patient:
+                # if the ptient does not exist, create them
+                hn_to_patient[hn].append(
+                    create_rfh_patient_from_hospital_number(
+                        hn, InfectionService
+                    )
+                )
 
         BedStatus.objects.all().delete()
 
         for bed_data in status:
-            bed_status = BedStatus()
-            for k, v in bed_data.items():
-                setattr(
-                    bed_status,
-                    BedStatus.UPSTREAM_FIELDS_TO_MODEL_FIELDS[k],
-                    v
-                )
-
-            if bed_status.local_patient_identifier:
-                patient = Patient.objects.filter(
-                    demographics__hospital_number=bed_status.local_patient_identifier
-                ).first()
-
-                if patient:
+            if not bed_data["Local_Patient_Identifier"]:
+                continue
+            for patient in hn_to_patient[bed_data["Local_Patient_Identifier"]]:
+                bed_status = BedStatus()
+                for k, v in bed_data.items():
+                    setattr(
+                        bed_status,
+                        BedStatus.UPSTREAM_FIELDS_TO_MODEL_FIELDS[k],
+                        v
+                    )
                     bed_status.patient = patient
-                else:
-                    patient = create_rfh_patient_from_hospital_number(
-                        bed_status.local_patient_identifier, InfectionService)
-                    bed_status.patient = patient
-
-            bed_status.save()
+                bed_status.save()

--- a/plugins/handover/loader.py
+++ b/plugins/handover/loader.py
@@ -165,6 +165,7 @@ def sync_amt_handover():
     discharged = AMTHandover.objects.exclude(
         sqlserver_id__in=current_ids
     ).filter(discharged='N')
+    api = ProdAPI()
 
     for handover in discharged:
         upstream = api.execute_hospital_query(


### PR DESCRIPTION
This fixes all loaders where the upstream does not use prefixed zeros. In this case fixes means that the loaders will save for all patients whether prefixed by zeros or if they are duplicates.

This means
* When loading for a specific patient we strip off the leading zeros.
* When loading since a certain time we update all patients if they are prefixed with zeros or not.

It uses the `hospital_numbers_to_patients` which returns a list of patients for a hospital number. This is when we have multiple patients with the same hospital number or patients where their hospital number without preceding zeros is the same.

The plan would be to change `hospital_numbers_to_patients` to account for merged patients in the future.

This can be released now. We should rerun the loaders for all patients with prefixed zeros.