### PR TITLE
No more add patient with zero prefixes

### DIFF
--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -101,7 +101,7 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
 
         hospital = ""
         if "location" in data:
-            hospital = data['location'][0]['hospital']
+            hospital = data['location'][0].get('hospital')
 
         if patient:
             if hospital == 'RNOH':
@@ -120,6 +120,13 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
                 return super(AddPatientPathway, self).save(
                     data, user=user, patient=patient, episode=infectious_episode
                 )
+        else:
+            # strip off leading zeros, we do not create patients
+            # who have leading zeros.
+            hn = data["demographics"][0].get("hospital_number")
+            if hn:
+                hn = data["demographics"][0]["hospital_number"].lstrip('0')
+                data["demographics"][0]["hospital_number"] = hn
 
         saved_patient, saved_episode = super(AddPatientPathway, self).save(
             data, user=user, patient=patient, episode=episode

--- a/elcid/test/test_pathways.py
+++ b/elcid/test/test_pathways.py
@@ -10,6 +10,7 @@ from elcid.pathways import (
     AddPatientPathway, IgnoreDemographicsMixin
 )
 from elcid import episode_categories
+from elcid import models as emodels
 
 
 @override_settings(
@@ -199,4 +200,15 @@ class TestAddPatientPathway(OpalTestCase):
         self.assertEqual(
             list(episode.get_tag_names(None)),
             ['antifungal']
+        )
+
+    def test_create_new_patient_with_stripped_zeros(self):
+        url = AddPatientPathway().save_url()
+        test_data = dict(
+            demographics=[dict(hospital_number="00234", nhs_number="12312")],
+            tagging=[{u'antifungal': True}]
+        )
+        self.post_json(url, test_data)
+        self.assertTrue(
+            emodels.Demographics.objects.filter(hospital_number="234").exists()
         )


### PR DESCRIPTION
When we search for a patient in the add patient flow, match any patient if they have prefixed zeros. e.g. if you try and add 193 and 00193 exists in elcid then match 00193. This is to stop duplicates being created in our system.

If no patient is matched and we are going to create a patient then make sure we strip off the prefixed zeros before creating them. We should not be creating any new patients with prefixed zeros.
