### PR TITLE
Add patient no zero prefixes

### DIFF
--- a/elcid/api.py
+++ b/elcid/api.py
@@ -563,7 +563,10 @@ class DemographicsSearch(LoginRequiredViewset):
     PATIENT_NOT_FOUND = "patient_not_found"
 
     def list(self, request, *args, **kwargs):
-        hospital_number = request.query_params.get("hospital_number")
+        hospital_number = request.query_params.get("hospital_number", "")
+        # We should never have hospital numbers prefixed with 0
+        # as VIEW_CRS_Patient_Masterfile does not.
+        hospital_number = hospital_number.lstrip('0')
         if not hospital_number:
             return HttpResponseBadRequest("Please pass in a hospital number")
         demographics = emodels.Demographics.objects.filter(

--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -120,6 +120,13 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
                 return super(AddPatientPathway, self).save(
                     data, user=user, patient=patient, episode=infectious_episode
                 )
+        else:
+            # strip off leading zeros, we do not create patients
+            # who have leading zeros.
+            hn = data["demographics"][0].get("hospital_number")
+            if hn:
+                hn = data["demographics"][0]["hospital_number"].lstrip('0')
+                data["demographics"][0]["hospital_number"] = hn
 
         saved_patient, saved_episode = super(AddPatientPathway, self).save(
             data, user=user, patient=patient, episode=episode

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -452,7 +452,7 @@ class DemographicsSearchTestCase(OpalTestCase):
     ):
         load_demographics.return_value = dict(first_name="Wilma")
         response = json.loads(
-            self.client.get(self.url).content.decode('utf-8')
+            self.client.get(self.get_url('01')).content.decode('utf-8')
         )
         self.assertEqual(
             response["status"], "patient_found_upstream"
@@ -460,10 +460,46 @@ class DemographicsSearchTestCase(OpalTestCase):
         self.assertEqual(
             response["patient"]["demographics"][0]["first_name"], "Wilma"
         )
+        load_demographics.assert_called_once_with('1')
+
+    @override_settings(USE_UPSTREAM_DEMOGRAPHICS=True)
+    @mock.patch("elcid.api.loader.load_demographics")
+    def test_with_demographics_add_patient_found_upstream_without_zeros(
+        self, load_demographics
+    ):
+        """
+        When we query upstream demographics, query should use
+        the hn without preceding zeros.
+        """
+        load_demographics.return_value = dict(first_name="Wilma")
+        response = json.loads(
+            self.client.get(self.get_url('01')).content.decode('utf-8')
+        )
+        self.assertEqual(
+            response["status"], "patient_found_upstream"
+        )
+        self.assertEqual(
+            response["patient"]["demographics"][0]["first_name"], "Wilma"
+        )
+        load_demographics.assert_called_once_with('1')
 
     def test_patient_found(self):
         self.get_patient("Wilma", "1")
         response = json.loads(self.client.get(self.url).content.decode('utf-8'))
+        self.assertEqual(
+            response["status"], "patient_found_in_elcid"
+        )
+        self.assertEqual(
+            response["patient"]["demographics"][0]["first_name"], "Wilma"
+        )
+
+    def test_with_demographics_add_patient_in_elcid_without_zeros(self):
+        """
+        When we querying within elcid, query should use
+        the hn without preceding zeros.
+        """
+        self.get_patient("Wilma", "1")
+        response = json.loads(self.client.get(self.get_url('01')).content.decode('utf-8'))
         self.assertEqual(
             response["status"], "patient_found_in_elcid"
         )

--- a/elcid/test/test_pathways.py
+++ b/elcid/test/test_pathways.py
@@ -10,6 +10,7 @@ from elcid.pathways import (
     AddPatientPathway, IgnoreDemographicsMixin
 )
 from elcid import episode_categories
+from elcid import models as emodels
 
 
 @override_settings(
@@ -199,4 +200,15 @@ class TestAddPatientPathway(OpalTestCase):
         self.assertEqual(
             list(episode.get_tag_names(None)),
             ['antifungal']
+        )
+
+    def test_create_new_patient_with_stripped_zeros(self):
+        url = AddPatientPathway().save_url()
+        test_data = dict(
+            demographics=[dict(hospital_number="00234", nhs_number="12312")],
+            tagging=[{u'antifungal': True}]
+        )
+        self.post_json(url, test_data)
+        self.assertTrue(
+            emodels.Demographics.objects.filter(hospital_number="234").exists()
         )


### PR DESCRIPTION
When we add a patient.

* When we're looking to see if they already exist, strip the leading zeros as we do not expect locally or upstream to include patients with leading zeros.
* When we're creating the patient, strip any leading zeros. We should never create a patient with leading zeros.