### PR TITLE
Bug fix; Add patient hospital bug fix

### DIFF
--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -101,7 +101,7 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
 
         hospital = ""
         if "location" in data:
-            hospital = data['location'][0]['hospital']
+            hospital = data['location'][0].get('hospital', "")
 
         if patient:
             if hospital == 'RNOH':

--- a/elcid/test/test_pathways.py
+++ b/elcid/test/test_pathways.py
@@ -165,6 +165,24 @@ class TestAddPatientPathway(OpalTestCase):
             []
         )
 
+    def test_does_not_error_if_hospital_is_not_set(self):
+        test_data = dict(
+            demographics=[dict(hospital_number="234", nhs_number="12312")],
+            location=[dict(ward="9W")]
+        )
+        self.post_json(self.url, test_data)
+        patient = models.Patient.objects.get()
+        self.assertEqual(
+            patient.demographics_set.first().hospital_number,
+            "234"
+        )
+        episode = patient.episode_set.get()
+        self.assertEqual(
+            list(episode.get_tag_names(None)),
+            []
+        )
+
+
     @patch("elcid.pathways.datetime")
     def test_episode_start(self, datetime):
         patient, episode = self.new_patient_and_episode_please()


### PR DESCRIPTION
To see the bug.

Add a patient, do not click into the hospital text field when on the location field.

Then try and save the patient. The pathway should error.

This is because the hospital field is only populated if the user has clicked into the hospital input.

The solution is to default the hospital to an empty string.