### PR TITLE
Create patient from upstream data sources

### DIFF
--- a/elcid/views.py
+++ b/elcid/views.py
@@ -249,6 +249,10 @@ class AddAntifungalPatients(LoginRequiredMixin, TemplateView):
                 patient.create_episode(
                     category_name=InfectionService.display_name
                 )
+                if 'hospital_number' in demographics_dict:
+                    hn = demographics_dict['hospital_number'].lstrip('0')
+                    demographics_dict['hospital_number'] = hn
+
                 demos = patient.demographics_set.get()
                 demos.update_from_dict(
                     demographics_dict,

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -90,6 +90,11 @@ def create_rfh_patient_from_hospital_number(hospital_number, episode_category, r
 
     If a patient with this hospital number already exists raise ValueError
     """
+    if hospital_number.startswith('0'):
+        raise ValueError(
+            f'Unable to create a patient {hospital_number}. Hospital numbers within elcid should never start with a zero'
+        )
+
     if emodels.Demographics.objects.filter(hospital_number=hospital_number).exists():
         raise ValueError('Patient with this hospital number already exists')
 

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -89,10 +89,11 @@ def create_rfh_patient_from_hospital_number(hospital_number, episode_category, r
     It will create an episode of category EPISODE_CATEGORY for the patient.
 
     If a patient with this hospital number already exists raise ValueError
+    If a hospital number prefixed with zero is passed in raise ValueError
     """
     if hospital_number.startswith('0'):
         raise ValueError(
-            f'Unable to create a patient {hospital_number}. Hospital numbers within elcid should never start with a zero'
+            f'Unable to create a patient {hospital_number}. Hospital numbers within elCID should never start with a zero'
         )
 
     if emodels.Demographics.objects.filter(hospital_number=hospital_number).exists():

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -686,6 +686,6 @@ class CreateRfhPatientFromHospitalNumberTestCase(OpalTestCase):
             )
         expected = " ".join([
             "Unable to create a patient 0111.",
-            "Hospital numbers within elcid should never start with a zero"
+            "Hospital numbers within elCID should never start with a zero"
         ])
         self.assertEqual(str(v.exception), expected)

--- a/plugins/covid/loader.py
+++ b/plugins/covid/loader.py
@@ -40,7 +40,7 @@ def pre_load_covid_patients():
             params={'test_name': test_name, 'since': last_90_days}
         )
 
-        # lab test mrns can have preceding zeros, elCID does not use zero
+        # lab test MRNs can have preceding zeros, elCID does not use zero
         # prefixes as we match the upstream masterfile table
         mrns = [
             r['Patient_Number'].lstrip('0') for r in results if r['Patient_Number'].lstrip('0')

--- a/plugins/covid/loader.py
+++ b/plugins/covid/loader.py
@@ -40,8 +40,8 @@ def pre_load_covid_patients():
             params={'test_name': test_name, 'since': last_90_days}
         )
 
-        # lab tests can have preceding zeros, elcid does not user zero
-        # prefixes as we match the masterfile table
+        # lab test mrns can have preceding zeros, elCID does not use zero
+        # prefixes as we match the upstream masterfile table
         mrns = [
             r['Patient_Number'].lstrip('0') for r in results if r['Patient_Number'].lstrip('0')
         ]

--- a/plugins/covid/loader.py
+++ b/plugins/covid/loader.py
@@ -40,7 +40,12 @@ def pre_load_covid_patients():
             params={'test_name': test_name, 'since': last_90_days}
         )
 
-        patient_mrns.update([r['Patient_Number'] for r in results])
+        # lab tests can have preceding zeros, elcid does not user zero
+        # prefixes as we match the masterfile table
+        mrns = [
+            r['Patient_Number'].lstrip('0') for r in results if r['Patient_Number'].lstrip('0')
+        ]
+        patient_mrns.update(mrns)
 
     all_mrns = set(
         Demographics.objects.values_list('hospital_number', flat=True)

--- a/plugins/handover/loader.py
+++ b/plugins/handover/loader.py
@@ -184,7 +184,7 @@ def sync_nursing_handover():
 
     for handover in handovers:
 
-        # lab test mrns can have preceding zeros, elCID does not use zero
+        # nursing handover MRNs can have preceding zeros, elCID does not use zero
         # prefixes as we match the upstream masterfile table
         mrn    = handover['Patient_MRN'].lstrip('0')
         sql_id = handover['SQLserver_UniqueID']

--- a/plugins/handover/loader.py
+++ b/plugins/handover/loader.py
@@ -184,6 +184,8 @@ def sync_nursing_handover():
 
     for handover in handovers:
 
+        # lab test mrns can have preceding zeros, elCID does not use zero
+        # prefixes as we match the upstream masterfile table
         mrn    = handover['Patient_MRN'].lstrip('0')
         sql_id = handover['SQLserver_UniqueID']
 

--- a/plugins/handover/loader.py
+++ b/plugins/handover/loader.py
@@ -184,8 +184,11 @@ def sync_nursing_handover():
 
     for handover in handovers:
 
-        mrn    = handover['Patient_MRN']
+        mrn    = handover['Patient_MRN'].lstrip('0')
         sql_id = handover['SQLserver_UniqueID']
+
+        if not mrn:
+            continue
 
         if not Demographics.objects.filter(hospital_number=mrn).exists():
             create_rfh_patient_from_hospital_number(mrn, InfectionService)

--- a/plugins/icu/loader.py
+++ b/plugins/icu/loader.py
@@ -61,7 +61,7 @@ def load_icu_handover():
 
     for result in results:
 
-        # lab test mrns can have preceding zeros, elCID does not use zero
+        # ICU handover MRNs can have preceding zeros, elCID does not use zero
         # prefixes as we match the upstream masterfile table
         mrn = result['Patient_MRN'].lstrip('0')
 

--- a/plugins/icu/loader.py
+++ b/plugins/icu/loader.py
@@ -61,6 +61,8 @@ def load_icu_handover():
 
     for result in results:
 
+        # lab test mrns can have preceding zeros, elCID does not use zero
+        # prefixes as we match the upstream masterfile table
         mrn = result['Patient_MRN'].lstrip('0')
 
         if not mrn:

--- a/plugins/icu/loader.py
+++ b/plugins/icu/loader.py
@@ -61,7 +61,10 @@ def load_icu_handover():
 
     for result in results:
 
-        mrn = result['Patient_MRN']
+        mrn = result['Patient_MRN'].lstrip('0')
+
+        if not mrn:
+            continue
 
         if not Demographics.objects.filter(hospital_number=mrn).exists():
             create_rfh_patient_from_hospital_number(mrn, InfectionService)

--- a/plugins/tb/loader.py
+++ b/plugins/tb/loader.py
@@ -53,7 +53,7 @@ def create_patients_from_tb_tests():
             hns = hns.union([i["Patient_Number"] for i in query_result])
 
     for hn in list(hns):
-        # lab test mrns can have preceding zeros, elCID does not use zero
+        # lab test MRNs can have preceding zeros, elCID does not use zero
         # prefixes as we match the upstream masterfile table
         hn = hn.lstrip('0')
         # don't process empty hospital numbers

--- a/plugins/tb/loader.py
+++ b/plugins/tb/loader.py
@@ -53,6 +53,8 @@ def create_patients_from_tb_tests():
             hns = hns.union([i["Patient_Number"] for i in query_result])
 
     for hn in list(hns):
+        # lab test mrns can have preceding zeros, elCID does not use zero
+        # prefixes as we match the upstream masterfile table
         hn = hn.lstrip('0')
         # don't process empty hospital numbers
         if not hn:

--- a/plugins/tb/loader.py
+++ b/plugins/tb/loader.py
@@ -53,7 +53,7 @@ def create_patients_from_tb_tests():
             hns = hns.union([i["Patient_Number"] for i in query_result])
 
     for hn in list(hns):
-        hn = hn.strip()
+        hn = hn.lstrip('0')
         # don't process empty hospital numbers
         if not hn:
             continue


### PR DESCRIPTION
This PR handles all cases where we create a patient from an upstream source where that source uses prefixed zeros.

* Changes create_rfh_patient_from_hospital_number to raise ValueError if passed an hn with a prefixed zero
* Strips zero prefixes from hns when adding patients via AddAntifungalPatients
* Strip 0s from hns before creating patients from services that use prefixed 0s