### PR TITLE
Lab test leading zeros

### DIFF
--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -787,11 +787,23 @@ class ProdApi(base_api.BaseApi):
 
     @timing
     def results_for_hospital_number(self, hospital_number):
+        query = """
+        SELECT * FROM tQuest.Pathology_Result_view
+        WHERE Patient_Number IN (
+            @mrn_0, @mrn_1, @mrn_2, @mrn_3, @mrn_4
+        )
         """
-            returns all the results for a particular person
-
-            aggregated into labtest: observations([])
-        """
-        raw_rows = self.raw_data(hospital_number)
+        hn = hospital_number.strip('0')
+        hns = [f"{'0' * i}{hn}" for i in range(5)]
+        raw_rows = self.execute_trust_query(
+            query,
+            params=dict(
+                mrn_0=hns[0],
+                mrn_1=hns[1],
+                mrn_2=hns[2],
+                mrn_3=hns[3],
+                mrn_4=hns[4],
+            )
+        )
         rows = (PathologyRow(raw_row) for raw_row in raw_rows)
         return self.cast_rows_to_lab_test(rows)

--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -322,7 +322,10 @@ class PathologyRow(object):
 
     # Demographics Fields
     def get_hospital_number(self):
-        return self.db_row.get("Patient_Number")
+        # The lab test table has patients with preceding zeros
+        # elcid matches the master file table and strips these
+        # off.
+        return self.db_row.get("Patient_Number").lstrip('0')
 
     def get_nhs_number(self):
         return self.get_or_fallback(
@@ -789,7 +792,6 @@ class ProdApi(base_api.BaseApi):
 
             aggregated into labtest: observations([])
         """
-
         raw_rows = self.raw_data(hospital_number)
         rows = (PathologyRow(raw_row) for raw_row in raw_rows)
         return self.cast_rows_to_lab_test(rows)

--- a/intrahospital_api/test/test_prod_api.py
+++ b/intrahospital_api/test/test_prod_api.py
@@ -180,6 +180,13 @@ class PathologyRowTestCase(OpalTestCase):
         )
         self.assertEqual(row.get_hospital_number(), "1232")
 
+    def test_get_hospital_number_with_leading_zeros(self):
+        row = self.get_row(
+            Patient_Number="01232",
+        )
+        self.assertEqual(row.get_hospital_number(), "1232")
+
+
     def test_get_nhs_number(self):
         row = self.get_row(
             CRS_NHS_Number="1232",


### PR DESCRIPTION
1. Make sure that when saving lab tests from we strip off prefixed zeros from hospital numbers
2. Make sure when querying by hospital number for lab tests upstream we check to see if there are any lab tests attached to the hn but where the hn has preceding zeros.

Note we use an in query because it takes ~13 seconds, if we do it in serial and aggregate  takes ~20 seconds