### PR TITLE
Remove the verbose unused demographics loader logging

### DIFF
--- a/intrahospital_api/update_demographics.py
+++ b/intrahospital_api/update_demographics.py
@@ -151,7 +151,6 @@ def update_if_changed(instance, update_dict):
 
     If a field has changed, update it and save the instance.
     """
-    time_start = time()
     changed = False
     for field, new_val in update_dict.items():
         old_val = getattr(instance, field)
@@ -187,13 +186,8 @@ def update_if_changed(instance, update_dict):
             changed = True
 
         if changed:
-            logger.info(
-                f"for {instance} {field} has changed was {old_val} now {new_val}"
-            )
             setattr(instance, field, new_val)
     if changed:
-        time_end = time()
-        logger.info(f"updated {instance.__class__.__name__} in {time_end-time_start}")
         instance.updated_by = api.user
         instance.updated = timezone.now()
         instance.external_system = EXTERNAL_SYSTEM
@@ -233,9 +227,6 @@ def update_patient_subrecords_from_upstream_dict(patient, upstream_patient_infor
     # we should never update the hospital_number, so restore it here
     hn = demographics.hospital_number
     upstream_demographics_dict["hospital_number"] = hn
-    logger.info(
-        f"patient information: checking {patient.id}, hn: {hn}"
-    )
     update_if_changed(demographics, upstream_demographics_dict)
     update_if_changed(gp_details, upstream_gp_details)
     update_if_changed(contact_information, upstream_contact_information)


### PR DESCRIPTION
We never check it and we log substantially more than we do for the other loaders. Lets strip it out.

Sample log after this is implemented
```
2022-11-22 11:26:54,024 12966 139767910008640 update_demographics.py update_patient_information_since INFO patient information: loading patient information since 2022-11-22 07:26:53.996357+00:00
2022-11-22 11:26:54,040 12966 139767910008640 prod_api.py execute_hospital_query INFO Running upstream query
SELECT * FROM VIEW_CRS_Patient_Masterfile WHERE
last_updated > @last_updated OR
insert_date > @last_updated
 {'last_updated': datetime.datetime(2022, 11, 22, 7, 26, 53, 996357, tzinfo=<UTC>)}
2022-11-22 11:26:55,996 12966 139767910008640 utils.py wrap INFO timing_func: 'patient_masterfile_since' 1.9724 sec
2022-11-22 11:26:55,997 12966 139767910008640 update_demographics.py get_patients_from_master_file_rows INFO starting patient query
2022-11-22 11:28:00,929 12966 139767910008640 update_demographics.py get_patients_from_master_file_rows INFO ending patient query
2022-11-22 11:28:04,055 12966 139767910008640 update_demographics.py update_patient_information_since INFO patient information: query time 0.032877981662750244
2022-11-22 11:28:04,055 12966 139767910008640 update_demographics.py update_patient_information_since INFO patient information: update time 1.1342994650204976
2022-11-22 11:28:04,055 12966 139767910008640 update_demographics.py update_patient_information_since INFO patient information: row count 7680
2022-11-22 11:28:04,055 12966 139767910008640 update_demographics.py update_patient_information_since INFO patient information: patients found 7680
2022-11-22 11:28:04,055 12966 139767910008640 update_demographics.py update_patient_information_since INFO patient information: patients updated 857
```

Which I think is more managable/useful