### PR TITLE
Changes the query for results to also query zero prefix MRNs

### DIFF
--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -782,14 +782,38 @@ class ProdApi(base_api.BaseApi):
             result.append(lab_test)
         return result
 
+    def query_for_zero_prefixed(self, hospital_number):
+        """
+        Returns zero prefixed versions of the hospital
+        number if they exist in the results table.
+
+        We do not use prefixed zeros for MRNs as we match
+        the master file but the results table does, so get
+        any zero prefixed MRNs included in the table for
+        the MRN.
+        """
+        query = """
+        SELECT DISTINCT Patient_Number FROM tQuest.Pathology_Result_View
+        WHERE Patient_Number LIKE '%%0' + @hospital_number
+        """
+        other_hns = self.execute_trust_query(
+            query, params={"hospital_number": hospital_number}
+        )
+        # we know the above query returns us false positives
+        # e.g. if we look for 0234 it will return 20234
+        return [
+            i["Patient_Number"] for i in other_hns if i["Patient_Number"].lstrip('0') == hospital_number
+        ]
+
     @timing
     def results_for_hospital_number(self, hospital_number):
         """
-            returns all the results for a particular person
-
-            aggregated into labtest: observations([])
+        returns all the results for an MRN
+        aggregated into labtest: observations([])
         """
-
+        other_hns = self.query_for_zero_prefixed(hospital_number)
         raw_rows = self.raw_data(hospital_number)
+        for other_hn in other_hns:
+            raw_rows.extend(self.raw_data(other_hn))
         rows = (PathologyRow(raw_row) for raw_row in raw_rows)
         return self.cast_rows_to_lab_test(rows)

--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -799,7 +799,7 @@ class ProdApi(base_api.BaseApi):
         other_hns = self.execute_trust_query(
             query, params={"hospital_number": hospital_number}
         )
-        # we know the above query returns us false positives
+        # we know the above query may return false positives
         # e.g. if we look for 0234 it will return 20234
         return [
             i["Patient_Number"] for i in other_hns if i["Patient_Number"].lstrip('0') == hospital_number


### PR DESCRIPTION
If an MRN also has zero prefixed versions in the results table make sure include these as well.

BTW this method is ~twice as fast as the in clause method.