### PR TITLE
135 write to epr initials

### DIFF
--- a/elcid/assets/js/elcid/controllers/clinical_timeline.js
+++ b/elcid/assets/js/elcid/controllers/clinical_timeline.js
@@ -73,7 +73,7 @@ angular.module('opal.controllers').controller(
             self.formItem = self.getClinicalAdviceFormObject();
 
             $scope.$watch("clinicalTimeline.formItem.editing", self.watchMicroFields, true);
-            self.save = function(){
+            self.save = function(form){
               ngProgressLite.set(0);
               ngProgressLite.start();
               self.formItem.save($scope.episode).then(function() {
@@ -81,6 +81,7 @@ angular.module('opal.controllers').controller(
                   self.changed = false;
                   self.formItem = self.getClinicalAdviceFormObject();
                   self.getClinicalAdvice();
+                  form.$setPristine()
               });
             };
         });

--- a/elcid/assets/js/elcidtest/clinical_timeline.controller.test.js
+++ b/elcid/assets/js/elcidtest/clinical_timeline.controller.test.js
@@ -3,7 +3,7 @@ describe('ClinicalAdviceFormTest', function() {
 
     var $scope, $httpBackend, $rootScope, $controller;
     var Episode, ctrl, opalTestHelper;
-    var mkcontroller, $modal;
+    var mkcontroller, $modal, fakeForm;
 
     var recorddata = {
             'microbiology_input': {
@@ -39,6 +39,8 @@ describe('ClinicalAdviceFormTest', function() {
                 $modal: $modal
             });
         };
+        fakeForm = {"$setPristine": function(){}};
+        spyOn(fakeForm, "$setPristine")
         $httpBackend.expectGET('/api/v0.1/referencedata/').respond({});
         $httpBackend.expectGET('/api/v0.1/record/').respond(recorddata);
     });
@@ -188,18 +190,19 @@ describe('ClinicalAdviceFormTest', function() {
         $httpBackend.flush();
       });
 
-      it('should reset item', function(){
+      fit('should reset item', function(){
         ctrl.changed = true
         spyOn(ctrl.formItem, "save").and.returnValue({
           then: function(x){ x() }
         });
         spyOn(ctrl, "getClinicalAdviceFormObject");
         spyOn(ctrl, "getClinicalAdvice");
-        ctrl.save();
+        ctrl.save(fakeForm);
         $rootScope.$apply();
         expect(ctrl.getClinicalAdviceFormObject).toHaveBeenCalledWith();
         expect(ctrl.getClinicalAdvice).toHaveBeenCalledWith();
         expect(ctrl.changed).toBe(false);
+        expect(fakeForm.$setPristine).toHaveBeenCalledWith();
       });
     });
 

--- a/elcid/templates/forms/microbiology_input_form.html
+++ b/elcid/templates/forms/microbiology_input_form.html
@@ -1,6 +1,6 @@
 {% load forms %}
 {% datetimepicker model="formItem.editing.when" field="MicrobiologyInput.when" %}
-{% input model="formItem.editing.initials" field="MicrobiologyInput.initials" %}
+{% input model="formItem.editing.initials" required=True field="MicrobiologyInput.initials" %}
 {% select model="formItem.editing.reason_for_interaction" field="MicrobiologyInput.reason_for_interaction" %}
 
 <span ng-show="formItem.editing.reason_for_interaction === '{{ models.MicrobiologyInput.ICU_REASON_FOR_INTERACTION }}'">

--- a/elcid/templates/forms/microbiology_input_form.html
+++ b/elcid/templates/forms/microbiology_input_form.html
@@ -1,6 +1,11 @@
 {% load forms %}
 {% datetimepicker model="formItem.editing.when" field="MicrobiologyInput.when" %}
-{% input model="formItem.editing.initials" required=True field="MicrobiologyInput.initials" %}
+<div class="form-group">
+  <label class="control-label col-sm-3">Initials</label>
+  <div ng-class="{'has-error': form.$submitted && form.initials.$error}" class="col-sm-8">
+    <input class="form-control" type="text" ng-model="formItem.editing.initials" autocomplete="off" name="initials" required="1" ng-maxlength="255">
+  </div>
+</div>
 {% select model="formItem.editing.reason_for_interaction" field="MicrobiologyInput.reason_for_interaction" %}
 
 <span ng-show="formItem.editing.reason_for_interaction === '{{ models.MicrobiologyInput.ICU_REASON_FOR_INTERACTION }}'">
@@ -13,3 +18,18 @@
 {% textarea model="formItem.editing.infection_control" field="MicrobiologyInput.infection_control" %}
 {% input model="formItem.editing.discussed_with" field="MicrobiologyInput.discussed_with" %}
 {% textarea model="formItem.editing.agreed_plan" field="MicrobiologyInput.agreed_plan" %}
+
+<div class="row">
+  <div class="help-block col-md-8 col-md-push-3 text-center" ng-show="form.$submitted && form.initials.$error.required">
+    <p class="text-danger">
+      Initials are required
+    </p>
+  </div>
+</div>
+<div class="row">
+  <div class="help-block col-md-8 col-md-push-3 text-center" ng-show="form.$submitted && form.initials.$error.maxlength">
+    <p class="text-danger">
+      The maximum length for initials is 255
+    </p>
+  </div>
+</div>

--- a/elcid/templates/inline_forms/clinical_timeline.html
+++ b/elcid/templates/inline_forms/clinical_timeline.html
@@ -72,6 +72,6 @@
 {% endblock %}
 
 {% block send_upstream_button %}
-<i ng-show="item.reason_for_interaction && item.reason_for_interaction.indexOf('RNOH') !== 0" class="fa fa-exchange edit pull-right pointer"
+<i ng-show="item.reason_for_interaction && item.reason_for_interaction.indexOf('RNOH') === -1" class="fa fa-exchange edit pull-right pointer"
    ng-click="open_modal('SendUpstreamCtrl', '/templates/send_upstream_modal.html', {patient:patient, item:item, refresh_patient:refresh, refresh_timeline:clinicalTimeline.getClinicalAdvice})"></i>
 {% endblock %}

--- a/elcid/templates/inline_forms/clinical_timeline.html
+++ b/elcid/templates/inline_forms/clinical_timeline.html
@@ -72,6 +72,6 @@
 {% endblock %}
 
 {% block send_upstream_button %}
-<i class="fa fa-exchange edit pull-right pointer"
+<i ng-show="item.reason_for_interaction && item.reason_for_interaction.indexOf('RNOH') !== 0" class="fa fa-exchange edit pull-right pointer"
    ng-click="open_modal('SendUpstreamCtrl', '/templates/send_upstream_modal.html', {patient:patient, item:item, refresh_patient:refresh, refresh_timeline:clinicalTimeline.getClinicalAdvice})"></i>
 {% endblock %}

--- a/elcid/templates/inline_forms/clinical_timeline_base.html
+++ b/elcid/templates/inline_forms/clinical_timeline_base.html
@@ -1,30 +1,34 @@
 {% load forms %}
 <div ng-controller="ClinicalTimeline as clinicalTimeline">
   {% if not user.profile.readonly %}
-  <div  class="panel panel-default hidden-print">
-    <div class="panel-heading"><h3>
-        <i class="fa fa-comments"></i> Clinical Advice
-    </div></h3>
-    <div class="panel-body">
-      <div class="row">
-        <div class="col-md-12">
-          <form class="form-horizontal">
-            <div ng-repeat="formItem in [clinicalTimeline.formItem]">
-              {% block form_template %}{% endblock %}
-            </div>
-          </form>
+  <form name="form" ng-submit="" class="form-horizontal" novalidate>
+    <div class="panel panel-default hidden-print">
+      <div class="panel-heading"><h3>
+          <i class="fa fa-comments"></i> Clinical Advice
+      </div></h3>
+      <div class="panel-body">
+        <div class="row">
+          <div class="col-md-12">
+              <div ng-repeat="formItem in [clinicalTimeline.formItem]">
+                {% block form_template %}{% endblock %}
+              </div>
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-md-12 text-right">
-          <button ng-disabled="!clinicalTimeline.changed" class="btn btn-primary" ng-click="clinicalTimeline.save('save')">
-            <i class="fa fa-save"></i>
-            Save
-          </button>
+        <div class="row">
+          <div class="col-md-12 text-right">
+            <button ng-show="clinicalTimeline.changed" check-form="form" class="btn btn-primary" ng-click="form.$valid && clinicalTimeline.save(form)">
+              <i class="fa fa-save"></i>
+              Save
+            </button>
+            <button disabled ng-show="!clinicalTimeline.changed" class="btn btn-primary">
+              <i class="fa fa-save"></i>
+              Save
+            </button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </form>
   {% endif %}
 
   <div ng-show="clinicalTimeline.clinicalAdvice.length" class="panel panel-default hidden-print">

--- a/elcid/templates/inline_forms/clinical_timeline_base.html
+++ b/elcid/templates/inline_forms/clinical_timeline_base.html
@@ -16,6 +16,7 @@
         </div>
         <div class="row">
           <div class="col-md-12 text-right">
+            {# We do show hide logic rather than ng-disabled because the check-form directive also alters disabled state #}
             <button ng-show="clinicalTimeline.changed" check-form="form" class="btn btn-primary" ng-click="form.$valid && clinicalTimeline.save(form)">
               <i class="fa fa-save"></i>
               Save

--- a/elcid/templates/inline_forms/patient_consultation.html
+++ b/elcid/templates/inline_forms/patient_consultation.html
@@ -1,26 +1,31 @@
 {% load forms %}
 
 <div ng-controller="PatientConsultationForm as patientConsultationForm" class="panel panel-default hidden-print">
-    <div class="panel-heading"><h3>
-        <i class="fa fa-comments"></i> Clinical Note
-    </div></h3>
+  <form name="form" ng-submit="" class="form-horizontal" novalidate>
+      <div class="panel-heading"><h3>
+          <i class="fa fa-comments"></i> Clinical Note
+      </div></h3>
       <div class="panel-body">
           <div class="row">
             <div class="col-md-12">
-              <form class="form-horizontal">
-                <div ng-repeat="editing in [patientConsultationForm.editing]">
-                  {% include models.PatientConsultation.get_form_template %}
-                </div>
-              </form>
+              <div ng-repeat="editing in [patientConsultationForm.editing]">
+                {% include models.PatientConsultation.get_form_template %}
+              </div>
             </div>
-        </div>
-      <div class="row">
+          </div>
+        <div class="row">
           <div class="col-md-12 text-right">
-              <button ng-disabled="!patientConsultationForm.changed" class="btn btn-primary" ng-click="patientConsultationForm.save('save')">
+            {# We do show hide logic rather than ng-disabled because the check-form directive also alters disabled state #}
+            <button ng-show="patientConsultationForm.changed" check-form="form" class="btn btn-primary" ng-click="form.$valid && patientConsultationForm.save(form)">
               <i class="fa fa-save"></i>
               Save
-              </button>
+            </button>
+            <button disabled ng-show="!patientConsultationForm.changed" class="btn btn-primary">
+              <i class="fa fa-save"></i>
+              Save
+            </button>
           </div>
+        </div>
       </div>
-     </div>
+    </form>
  </div>

--- a/plugins/covid/templates/forms/covid_follow_up_call_follow_up_call_form.html
+++ b/plugins/covid/templates/forms/covid_follow_up_call_follow_up_call_form.html
@@ -6,7 +6,7 @@
 </div>
 <div class="row">
   <div class="col-md-4 col-md-offset-1">
-    {% input field="CovidFollowUpCallFollowUpCall.clinician" style="vertical" %}
+    {% input field="CovidFollowUpCallFollowUpCall.clinician" required=True style="vertical" %}
   </div>
   <div class="col-md-4 col-md-offset-1">
     {% select field="CovidFollowUpCallFollowUpCall.position" style="vertical" %}

--- a/plugins/covid/templates/forms/covid_follow_up_call_form.html
+++ b/plugins/covid/templates/forms/covid_follow_up_call_form.html
@@ -9,7 +9,7 @@
 </div>
 <div class="row">
   <div class="col-md-4 col-md-offset-1">
-    {% input field="CovidFollowUpCall.clinician" style="vertical" %}
+    {% input field="CovidFollowUpCall.clinician" required=True style="vertical" %}
   </div>
   <div class="col-md-4 col-md-offset-1">
     {% select field="CovidFollowUpCall.position" style="vertical" %}

--- a/plugins/covid/templates/forms/covid_six_month_follow_up_form.html
+++ b/plugins/covid/templates/forms/covid_six_month_follow_up_form.html
@@ -1,6 +1,6 @@
 {% load forms %}
 {% datetimepicker field="CovidSixMonthFollowUp.when" %}
-{% input field="CovidSixMonthFollowUp.clinician" %}
+{% input field="CovidSixMonthFollowUp.clinician" required=True %}
 {% input field="CovidSixMonthFollowUp.position" %}
 {% radio field="CovidSixMonthFollowUp.cxr_completed" %}
 {% radio field="CovidSixMonthFollowUp.bloods_completed" %}

--- a/plugins/ipc/templates/forms/icu_clinical_advice_form.html
+++ b/plugins/ipc/templates/forms/icu_clinical_advice_form.html
@@ -1,7 +1,7 @@
 {% load forms %}
 
 {% datetimepicker model="formItem.editing.when" field="MicrobiologyInput.when" %}
-{% input model="formItem.editing.initials" field="MicrobiologyInput.initials" %}
+{% input model="formItem.editing.initials" required=True field="MicrobiologyInput.initials" %}
 {% select model="formItem.editing.reason_for_interaction" field="MicrobiologyInput.reason_for_interaction" lookuplist="['ICN Ward Review']"%}
 
 <div ng-controller="IPCFormAdviceHelper as ipcFormAdviceHelper">

--- a/plugins/rnoh/templates/detail/rnoh.html
+++ b/plugins/rnoh/templates/detail/rnoh.html
@@ -171,30 +171,34 @@
 
 
       {% if not user.profile.readonly %}
-      <div  class="panel panel-default hidden-print">
-        <div class="panel-heading"><h3>
-            <i class="fa fa-comments"></i> Clinical Advice
-        </div></h3>
-        <div class="panel-body">
-          <div class="row">
-            <div class="col-md-12">
-              <form class="form-horizontal">
+      <form name="form" ng-submit="" class="form-horizontal" novalidate>
+        <div  class="panel panel-default hidden-print">
+          <div class="panel-heading"><h3>
+              <i class="fa fa-comments"></i> Clinical Advice
+          </div></h3>
+          <div class="panel-body">
+            <div class="row">
+              <div class="col-md-12">
                 <div ng-repeat="formItem in [clinicalTimeline.formItem]">
                   {% include 'rnoh/narrative_form.html' %}
                 </div>
-              </form>
+              </div>
             </div>
-          </div>
-          <div class="row">
-            <div class="col-md-12 text-right">
-              <button ng-disabled="!clinicalTimeline.changed" class="btn btn-primary" ng-click="clinicalTimeline.save('save')">
-                <i class="fa fa-save"></i>
-                Save
-              </button>
+            <div class="row">
+              <div class="col-md-12 text-right">
+                <button ng-show="clinicalTimeline.changed" check-form="form" class="btn btn-primary" ng-click="form.$valid && clinicalTimeline.save(form)">
+                  <i class="fa fa-save"></i>
+                  Save
+                </button>
+                <button disabled ng-show="!clinicalTimeline.changed" class="btn btn-primary">
+                  <i class="fa fa-save"></i>
+                  Save
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      </form>
       {% endif %}
 
 

--- a/plugins/tb/templates/forms/patient_consultation_form.html
+++ b/plugins/tb/templates/forms/patient_consultation_form.html
@@ -1,5 +1,5 @@
 {% load forms %}
-{% input field="PatientConsultation.initials" %}
+{% input required=True field="PatientConsultation.initials" %}
 {% select field="PatientConsultation.reason_for_interaction" %}
 {% datetimepicker field="PatientConsultation.when" %}
 {% textarea field="PatientConsultation.examination_findings" %}

--- a/plugins/tb/templates/forms/patient_consultation_form.html
+++ b/plugins/tb/templates/forms/patient_consultation_form.html
@@ -1,5 +1,10 @@
 {% load forms %}
-{% input required=True field="PatientConsultation.initials" %}
+<div class="form-group">
+  <label class="control-label col-sm-3">Initials</label>
+  <div ng-class="{'has-error': form.$submitted && form.initials.$error}" class="col-sm-8">
+    <input class="form-control" type="text" ng-model="editing.patient_consultation.initials" autocomplete="off" name="initials" required="1" ng-maxlength="255">
+  </div>
+</div>
 {% select field="PatientConsultation.reason_for_interaction" %}
 {% datetimepicker field="PatientConsultation.when" %}
 {% textarea field="PatientConsultation.examination_findings" %}
@@ -16,3 +21,18 @@
 </div>
 {% textarea field="PatientConsultation.discussion" %}
 {% textarea field="PatientConsultation.plan" %}
+
+<div class="row">
+  <div class="help-block col-md-8 col-md-push-3 text-center" ng-show="form.$submitted && form.initials.$error.required">
+    <p class="text-danger">
+      Initials are required
+    </p>
+  </div>
+</div>
+<div class="row">
+  <div class="help-block col-md-8 col-md-push-3 text-center" ng-show="form.$submitted && form.initials.$error.maxlength">
+    <p class="text-danger">
+      The maximum length for initials is 255
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
EPR requires a written_by field.

In TB patient consulations and other services microbiology input this is populated by the initials field. 

We change the timeline to accept standard opal template tag validation, in this case required=True. This means changing it so that after the form is submitted the form is marked as pristine. In angular terms this is not submitted and not dirty. This is so validation is reset for the next time the form is submitted.

With the covid branch its simpler. We populated the EPR initials field with the consulation from CovidFollowUpCall, CovidFollowUpCallFollowUpCall, CovidSixMonthFollowUp. We make this field required in the form, not in the model as we have existing data with None in the clinican.

Note the logic in the RNOH form is unchanged but because the API for the clinicalTimeline has change (save takes a form now), the template has been changed.
