### PR TITLE
Bug fix the create_rfh_patient loader method to read the async parameter

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -103,11 +103,7 @@ def create_rfh_patient_from_hospital_number(hospital_number, episode_category, r
         category_name=episode_category.display_name,
         start=datetime.date.today()
     )
-
-    if run_async is None:
-        load_patient(patient, run_async=run_async)
-    else:
-        load_patient(patient)
+    load_patient(patient, run_async=run_async)
     return patient
 
 


### PR DESCRIPTION
At the moment if you pass run_async to create_rfh_patient_from_hospital_number it will never be used.

This fixes that behaviour.