### PR TITLE
Merge search updates 1

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -460,7 +460,7 @@ OPAL_DEFAULT_SEARCH_FIELDS = [
     "demographics__first_name",
     "demographics__surname",
     # Search the normal fields but also
-    # include models that have been merged upstream
+    # include mrns that have been merged
     "mergedmrn__mrn"
 ]
 

--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -455,6 +455,15 @@ EXTRACT_ASYNC = False
 OPAL_SEARCH_BACKEND = "plugins.elcid_search.elcid_query.ElcidSearchQuery"
 WRITEBACK_ON = True
 
+OPAL_DEFAULT_SEARCH_FIELDS = [
+    "demographics__hospital_number",
+    "demographics__first_name",
+    "demographics__surname",
+    # Search the normal fields but also
+    # include models that have been merged upstream
+    "mergedmrn__mrn"
+]
+
 COVID_EXTRACT_LOCATION = os.path.join(PROJECT_PATH, '../prepared_downloads')
 
 REST_FRAMEWORK = {

--- a/elcid/templates/partials/_patient_summary_list.html
+++ b/elcid/templates/partials/_patient_summary_list.html
@@ -15,7 +15,7 @@
             <a class="orange-link" ng-href="[[ result.link ]]">
               [[ result.first_name ]] [[ result.surname ]] [[ result.hospitalNumber ]]
               <span ng-repeat="previousMRN in result.previous_mrns">
-                ([[ previousMRN ]])<span ng-show="!$last">,</span>
+                ([[ previousMRN ]])<span ng-show="!$last">;</span>
               </span>
             </a>
           </h4>

--- a/elcid/templates/partials/_patient_summary_list.html
+++ b/elcid/templates/partials/_patient_summary_list.html
@@ -1,0 +1,50 @@
+<div class="row">
+  <div class="col-sm-4 col-sm-push-4">
+    <h4>
+      We've found <strong>[[ paginator.totalCount ]]</strong> patient<span ng-if="results.length != 1">s</span>
+    </h4>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-6 col-sm-push-4">
+    <ul>
+      <li class="content-offset-10 content-offset-below-10" ng-repeat="result in results">
+        <div>
+          <h4 class="inline">
+            <a class="orange-link" ng-href="[[ result.link ]]">
+              [[ result.first_name ]] [[ result.surname ]] [[ result.hospitalNumber ]]
+              <span ng-repeat="previousMRN in result.previous_mrns">
+                ([[ previousMRN ]])<span ng-show="!$last">,</span>
+              </span>
+            </a>
+          </h4>
+          <span ng-show="result.dateOfBirth">
+            ([[ result.dateOfBirth | displayDate ]])
+          </span>
+        </div>
+        <div>
+          [[ result.count ]] Episode<span ng-show="result.count > 1">s</span> ([[ result.categories|title ]]) [[ result.years ]]
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-4 col-sm-push-4" ng-show="paginator.totalPages.length > 1">
+    <nav>
+      <ul class="pagination">
+        <li ng-if="paginator.hasPrevious">
+          <a ng-click="paginator.goPrevious()"><i class="fa fa-caret-left"></i></a>
+        </li>
+        <li ng-repeat="pageNum in paginator.totalPages" ng-class="{active: paginator.pageNumber == pageNum }">
+          <a ng-click="search(pageNum)">[[ pageNum ]]</a>
+        </li>
+        <li ng-if="paginator.hasNext">
+          <a ng-click="paginator.goNext()"><i class="fa fa-caret-right"></i></a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</div>

--- a/plugins/elcid_search/elcid_query.py
+++ b/plugins/elcid_search/elcid_query.py
@@ -1,7 +1,26 @@
-from opal.core.search.queries import DatabaseQuery
+from opal.core.search.queries import DatabaseQuery, PatientSummary
+from elcid import models
+
+
+class ElcidPatientSummary(PatientSummary):
+    def to_dict(self):
+        """
+        Adds the previous mrns that have been associated with the
+        patient to the patient summary.
+        """
+        result = super().to_dict()
+        previous_merges = models.MergedMRN.objects.filter(
+            patient_id=self.patient_id
+        ).order_by(
+            '-upstream_merge_datetime'
+        )
+        result["previous_mrns"] = list(previous_merges.values_list('mrn', flat=True))
+        return result
 
 
 class ElcidSearchQuery(DatabaseQuery):
+    patient_summary_class = ElcidPatientSummary
+
     def fuzzy_query(self):
         """
         Strips the zeros off the beginning of every item in the query.

--- a/plugins/elcid_search/tests/test_elcid_query.py
+++ b/plugins/elcid_search/tests/test_elcid_query.py
@@ -1,3 +1,5 @@
+import json
+from django.urls import reverse
 from opal.core.test import OpalTestCase
 from plugins.elcid_search import elcid_query
 
@@ -15,3 +17,61 @@ class ElcidQueryTestCase(OpalTestCase):
         query = elcid_query.ElcidSearchQuery(self.user, "0123")
         patients = query.fuzzy_query()
         self.assertEqual(list(patients), [patient])
+
+
+class FuzzySearchIncludesMergedPatientsTestCase(OpalTestCase):
+    """
+    When we do a fuzzy search we should also search merged patients
+    """
+    def test_fuzzy_search_includes_merged_patients(self):
+        patient, _ = self.new_patient_and_episode_please()
+        patient.demographics_set.update(
+            hospital_number="123"
+        )
+        patient.mergedmrn_set.create(
+            mrn="456"
+        )
+        query = elcid_query.ElcidSearchQuery(self.user, "456")
+        patients = query.fuzzy_query()
+        self.assertEqual(list(patients), [patient])
+
+
+class PatientSummaryTestCase(OpalTestCase):
+    def test_to_dict(self):
+        patient, episode = self.new_patient_and_episode_please()
+        patient.mergedmrn_set.create(
+            mrn="234"
+        )
+        result = elcid_query.ElcidPatientSummary(
+            patient, [episode]
+        ).to_dict()
+        self.assertEqual(
+            result['previous_mrns'], ["234"]
+        )
+
+class IntegerationTestCase(OpalTestCase):
+    def test_integration(self):
+        """
+        An integration test to make sure we are implementing
+        the opal search api as it is expected.
+
+        It searches for a zero prefixed merged MRN
+        and returns a json structure the correct MRN
+        along with the merged url
+        """
+        patient, _ = self.new_patient_and_episode_please()
+        patient.demographics_set.update(
+            hospital_number="123"
+        )
+        patient.mergedmrn_set.create(
+            mrn="234"
+        )
+        url = reverse('simple_search')
+        self.client.login(
+            username=self.user.username, password=self.PASSWORD
+        )
+        resp = self.client.get(url, data={"query": "0234"})
+        data = resp.json()
+        self.assertEqual(len(data["object_list"]), 1)
+        self.assertEqual(data["object_list"][0]["hospital_number"], "123")
+        self.assertEqual(data["object_list"][0]["previous_mrns"], ["234"])

--- a/plugins/elcid_search/tests/test_elcid_query.py
+++ b/plugins/elcid_search/tests/test_elcid_query.py
@@ -21,7 +21,7 @@ class ElcidQueryTestCase(OpalTestCase):
 
 class FuzzySearchIncludesMergedPatientsTestCase(OpalTestCase):
     """
-    When we do a fuzzy search we should also search merged patients
+    When we do a fuzzy search we should also search merged MRNs
     """
     def test_fuzzy_search_includes_merged_patients(self):
         patient, _ = self.new_patient_and_episode_please()

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ python-tds==1.8.2
 
 # Open Health Care
 opal-observations==0.5.0
--e git+https://github.com/openhealthcare/opal@change-to-url-in-patient-detail#egg=opal
+-e git+https://github.com/openhealthcare/opal@change-to-url-in-patient-detail-with-summary#egg=opal
 
 # Open Health Care repositories on GitHub
 -e git+https://github.com/openhealthcare/opal-passwordreset@v0.1#egg=opal_passwordreset


### PR DESCRIPTION
Changes it so that we include merged MRNs in a patients query results (ie if the patient MRN 123 was previously associated with MRN 234, a search result for 234 returns patient 123)

Changes it so that when we display the result we display the previously associated MRNs.

It does change the opal branch, its the previous opal branch + the patient summary change. At a later date we should check which opal branch to actually release from but that is out of the scope of this PR.

<img width="1215" alt="Screenshot 2022-12-01 at 22 52 24" src="https://user-images.githubusercontent.com/2175455/205176021-decf9981-a01c-46b8-a501-7bb4bfb8489d.png">
