### PR TITLE
Adds the update_from_dict method to the PreviousMRN mixin

### DIFF
--- a/elcid/models.py
+++ b/elcid/models.py
@@ -55,6 +55,22 @@ class PreviousMRN(models.Model):
     class Meta:
         abstract = True
 
+    def update_from_dict(self, data, *args, **kwargs):
+        """
+        The original MRN is set when a patient is merged and the subrecord
+        exists on the previous patient object.
+
+        When this happens the previous patient is deleted. If the
+        subrecord is subsequently editted then we can remove
+        this value as the user is updating the subrecord
+        in the context of the merged patient.
+        """
+        if self.previous_mrn is not None:
+            if 'previous_mrn' in data:
+                data.pop('previous_mrn')
+            self.previous_mrn = None
+        return super().update_from_dict(data, *args, **kwargs)
+
 
 
 class Demographics(PreviousMRN, omodels.Demographics, ExternallySourcedModel):

--- a/elcid/test/test_models.py
+++ b/elcid/test/test_models.py
@@ -101,6 +101,39 @@ class DemographicsTest(OpalTestCase, AbstractPatientTestCase):
             )
 
 
+class PreviousMRNTestCase(OpalTestCase):
+    def setUp(self):
+        _, self.episode = self.new_patient_and_episode_please()
+        self.procedure = self.episode.procedure_set.create()
+
+    def test_nones_previous_mrn_on_update(self):
+        self.procedure.previous_mrn = "123"
+        self.procedure.stage = "Stage 1"
+        self.procedure.save()
+        self.procedure.update_from_dict(
+            {
+                'stage': 'Stage 2',
+                'previous_mrn': '123'
+            },
+            None
+        )
+        procedure = self.episode.procedure_set.get()
+        self.assertEqual(
+            procedure.stage, "Stage 2"
+        )
+        self.assertIsNone(procedure.previous_mrn)
+
+    def test_does_not_error_if_previous_mrn_is_none(self):
+        self.procedure.stage = "Stage 1"
+        self.procedure.save()
+        self.procedure.update_from_dict({'stage': 'Stage 2'}, None)
+        procedure = self.episode.procedure_set.get()
+        self.assertEqual(
+            procedure.stage, "Stage 2"
+        )
+        self.assertIsNone(procedure.previous_mrn)
+
+
 class LocationTest(OpalTestCase, AbstractEpisodeTestCase):
 
     def setUp(self):
@@ -255,6 +288,29 @@ class MicrobiologyInputTestCase(OpalTestCase):
             saved_input.microinputicuroundrelation.icu_round.id,
             emodels.ICURound.objects.get().id
         )
+
+    def test_update_from_dict_zeros_previous_mrn(self):
+        update_dict = {
+            'when': '27/03/2020 09:33:55',
+            'initials': 'FJK',
+            'infection_control': 'asdf',
+            'clinical_discussion': 'asdf',
+            'reason_for_interaction': 'ICU round',
+            'micro_input_icu_round_relation': {
+                'observation': {'temperature': 1111},
+                'icu_round': {}
+            },
+            'episode_id': self.episode.id
+        }
+        micro_input = emodels.MicrobiologyInput(
+            episode=self.episode, previous_mrn="123"
+        )
+        micro_input.update_from_dict(update_dict, self.user)
+        saved_input = self.episode.microbiologyinput_set.get()
+        self.assertEqual(
+            saved_input.previous_mrn, None
+        )
+
 
     def test_update_from_dict_without_when(self):
         update_dict = {


### PR DESCRIPTION
The previous_mrn field is updated by the back end when an MRN is merged. It is used to tell the user that the subrecord was editted under a previous URL. After the subrecord is saved, we can remove the notice as its understood the user recognises that it was initially saved in a previous context.