### PR TITLE
Adds a message about the previous MRN to every modal form

### DIFF
--- a/elcid/templates/partials/_item_created_updated_by.html
+++ b/elcid/templates/partials/_item_created_updated_by.html
@@ -1,0 +1,31 @@
+{% load i18n %}
+<div ng-show="item.created || item.updated" class="content-offset-20">
+  <p class="text-muted text-center">
+    <span ng-show="item.previous_mrn">
+      <span ng-show="item.updated">Previously edited under MRN [[ item.previous_mrn ]]</span>
+      <br>
+    </span>
+    <span ng-hide="item.updated">
+      <img class="text-avatar" avatar-for-user="[[ item.created_by_id ]]">
+      <span ng-show="item.created_by_id">
+      {% trans "Created by" %}
+      </span>
+      <span ng-hide="item.created_by_id">
+        {% trans "Created" %}
+      </span>
+      <span full-name-for-user="[[ item.created_by_id ]]"></span>
+      [[ item.created | displayDate ]]
+    </span>
+    <span ng-show="item.updated">
+      <img class="text-avatar" avatar-for-user="[[ item.updated_by_id ]]">
+      <span ng-show="item.created_by_id">
+        {% trans "Last updated by" %}
+      </span>
+      <span ng-hide="item.created_by_id">
+        {% trans "Last updated" %}
+      </span>
+      <span full-name-for-user="[[ item.updated_by_id ]]"></span>
+      [[ item.updated | displayDate ]]
+    </span>
+  </p>
+</div>

--- a/elcid/templates/partials/_item_created_updated_by.html
+++ b/elcid/templates/partials/_item_created_updated_by.html
@@ -2,7 +2,7 @@
 <div ng-show="item.created || item.updated" class="content-offset-20">
   <p class="text-muted text-center">
     <span ng-show="item.previous_mrn">
-      <span ng-show="item.updated">Previously edited under MRN [[ item.previous_mrn ]]</span>
+      <span ng-show="item.updated">This information entered prior to patient merge under alternative MRN [[ item.previous_mrn ]]</span>
       <br>
     </span>
     <span ng-hide="item.updated">


### PR DESCRIPTION
At the bottom of every form above where it shows who/when last updated/created show the previous MRN that the subrecord was editted under if it exists.

Requirements said it should go along side, I put it above as I thought it looked better.

It was:
<img width="910" alt="Screenshot 2022-12-02 at 09 14 08" src="https://user-images.githubusercontent.com/2175455/205259546-492c1adb-154b-4e62-af71-a0e32700e116.png">

Becomes:
<img width="935" alt="Screenshot 2022-12-02 at 09 19 48" src="https://user-images.githubusercontent.com/2175455/205259560-3164e66d-81b3-43f9-a608-3bf6e9ef246a.png">

