### PR TITLE
Merge nationality pathway

### DIFF
--- a/elcid/models.py
+++ b/elcid/models.py
@@ -43,11 +43,11 @@ class MergedMRN(models.Model):
 
 class PreviousMRN(models.Model):
     """
-    A mixin for subrecords to maintain an audit trail for occasions 
+    A mixin for subrecords to maintain an audit trail for occasions
     when an upstream MRN merge occurs and the merged MRN has elCID entries.
-    
+
     `previous_mrn` is the MRN in use at the time that this subrecord instance
-    was last created/edited with if that MRN is different from the current 
+    was last created/edited with if that MRN is different from the current
     value of `Demographics.hospital_number` attached to this instance.
     """
     previous_mrn = models.CharField(blank=True, null=True, max_length=256)
@@ -65,10 +65,9 @@ class PreviousMRN(models.Model):
         this value as the user is updating the subrecord
         in the context of the merged patient.
         """
-        if self.previous_mrn is not None:
-            if 'previous_mrn' in data:
-                data.pop('previous_mrn')
-            self.previous_mrn = None
+        if 'previous_mrn' in data:
+            data.pop('previous_mrn')
+        self.previous_mrn = None
         return super().update_from_dict(data, *args, **kwargs)
 
 

--- a/elcid/test/test_models.py
+++ b/elcid/test/test_models.py
@@ -133,6 +133,19 @@ class PreviousMRNTestCase(OpalTestCase):
         )
         self.assertIsNone(procedure.previous_mrn)
 
+    def test_never_updates_from_the_front_end(self):
+        self.procedure.previous_mrn = None
+        self.procedure.save()
+        self.procedure.update_from_dict(
+            {'stage': 'Stage 2', 'previous_mrn': "234"},
+            None
+        )
+        procedure = self.episode.procedure_set.get()
+        self.assertEqual(
+            procedure.stage, "Stage 2"
+        )
+        self.assertIsNone(procedure.previous_mrn)
+
 
 class LocationTest(OpalTestCase, AbstractEpisodeTestCase):
 

--- a/plugins/tb/pathways.py
+++ b/plugins/tb/pathways.py
@@ -211,6 +211,19 @@ class NationalityAndLanguage(pathways.PagePathway):
             client_demographics = data.pop("demographics")
             our_demographics.birth_place = client_demographics[0]["birth_place"]
             our_demographics.save()
-        return super().save(
+
+            # We don't necessarily call update_from_dict on
+            # pathway subrecords, only if they are editted,
+            # so force removal of previous_mrn if we hit
+            # the save method.
+            patient.communinicationconsiderations_set.update(
+                previous_mrn=None
+            )
+            patient.nationality_set.update(
+                previous_mrn=None
+            )
+
+        result = super().save(
             data, user=user, episode=episode, patient=patient
         )
+        return result

--- a/plugins/tb/templates/pathway/steps/nationality_and_language.html
+++ b/plugins/tb/templates/pathway/steps/nationality_and_language.html
@@ -5,3 +5,8 @@
   {% include models.Nationality.get_form_template %}
 </div>
 {% include models.CommuninicationConsiderations.get_form_template %}
+
+
+<span ng-repeat="item in [editing.nationality]">
+  {% include "partials/_item_created_updated_by.html" %}
+</span>

--- a/plugins/tb/tests/test_pathways.py
+++ b/plugins/tb/tests/test_pathways.py
@@ -13,3 +13,56 @@ class ConditionalHelpStepTestCase(OpalTestCase):
             some_step.condition,
             "a == 1"
         )
+
+
+class NationalityAndLanguageTestCase(OpalTestCase):
+    def setUp(self):
+        self.patient, self.episode = self.new_patient_and_episode_please()
+        self.pathway = pathways.NationalityAndLanguage()
+
+    def test_nulls_out_communication_considerations(self):
+        data = {
+            "demographics": [{'birth_place': None}],
+            "nationality": [{
+                "id": self.patient.nationality_set.get().id,
+                "arrival_in_the_uk": "1956",
+                "previous_mrn": "234"
+            }]
+        }
+        self.patient.nationality_set.update(
+            previous_mrn="234"
+        )
+        self.patient.communinicationconsiderations_set.update(
+            previous_mrn="234"
+        )
+        self.pathway.save(
+            data,
+            episode=self.episode,
+            patient=self.patient
+        )
+        self.assertIsNone(
+            self.patient.communinicationconsiderations_set.get().previous_mrn
+        )
+        self.assertIsNone(
+            self.patient.nationality_set.get().previous_mrn
+        )
+
+    def test_nulls_out_nationality(self):
+        data = {
+            "demographics": [{'birth_place': None}],
+            "communication_considerations": [{
+                "arrival_in_the_uk": "1956",
+                "previous_mrn": "234"
+            }]
+        }
+        self.patient.nationality_set.update(
+            previous_mrn="234"
+        )
+        self.pathway.save(
+            data,
+            episode=self.episode,
+            patient=self.patient
+        )
+        self.assertIsNone(
+            self.patient.nationality_set.get().previous_mrn
+        )


### PR DESCRIPTION
This PR makes sure the nationality pathway displays the previous mrn in the footer and also removes the previous mrn on save.

Things to note...
1. The update_from_dict update...
So without this the tests fail, because in the case that you remove the previous_mrn and then call update_from_dict, the update_from_dict method saves the previous_mrn. In many ways this is an edge case however the situation is that the previous_mrn should _never_ be populated from the front end and we should always zero out the previous mrn on save. So this PR includes that.

2. Demographics
So this pathway updates a single field on Demographics. We ignore demographics.previous_mrn (on display and update) we just use the birth_place field which is not touched by the upstream api.

so lets review what this means,

A patient that previously has demographics (manually editted)
It will not show that a birth place previously added under another MRN as editted under another MRN. Now arguably this does not matter birth place is never added by upstream MRNs so it should not really matter which MRN it was added under. Alternatively I would suggest we move birth_place to nationality. Migrate the data to nationality, remove it from the demographics form and remove it from advanced search. Your call.
