### PR TITLE
Use the merged MRN when creating the patient

### DIFF
--- a/elcid/models.py
+++ b/elcid/models.py
@@ -43,11 +43,11 @@ class MergedMRN(models.Model):
 
 class PreviousMRN(models.Model):
     """
-    A mixin for subrecords to maintain an audit trail for occasions 
+    A mixin for subrecords to maintain an audit trail for occasions
     when an upstream MRN merge occurs and the merged MRN has elCID entries.
-    
+
     `previous_mrn` is the MRN in use at the time that this subrecord instance
-    was last created/edited with if that MRN is different from the current 
+    was last created/edited with if that MRN is different from the current
     value of `Demographics.hospital_number` attached to this instance.
     """
     previous_mrn = models.CharField(blank=True, null=True, max_length=256)
@@ -168,6 +168,11 @@ class MasterFileMeta(models.Model):
     """
     Meta data about the Patient_Masterfile upstream table
     """
+
+    # active_inactive is ACTIVE or INACTIVE
+    INACTIVE = "INACTIVE"
+    ACTIVE = "ACTIVE"
+
     patient = models.ForeignKey(omodels.Patient, on_delete=models.CASCADE)
     insert_date = models.DateTimeField(blank=True, null=True)
     last_updated = models.DateTimeField(blank=True, null=True)

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -90,6 +90,7 @@ def create_rfh_patient_from_hospital_number(hospital_number, episode_category, r
 
     If a patient with this hospital number already exists raise ValueError
     If a hospital number prefixed with zero is passed in raise ValueError
+    If the hospital number has already been merged into another raise ValueError
     """
     if hospital_number.startswith('0'):
         raise ValueError(
@@ -99,11 +100,17 @@ def create_rfh_patient_from_hospital_number(hospital_number, episode_category, r
     if emodels.Demographics.objects.filter(hospital_number=hospital_number).exists():
         raise ValueError('Patient with this hospital number already exists')
 
+    if emodels.MergedMRN.objects.filter(mrn=hospital_number):
+        raise ValueError('MRN has already been merged into another MRN')
+
     patient = Patient.objects.create()
 
-    demographics = patient.demographics()
-    demographics.hospital_number = hospital_number
-    demographics.save()
+    merged_mrn = update_demographics.upstream_merged_mrn(hospital_number)
+
+    if merged_mrn:
+        patient.demographics_set.update(hospital_number=merged_mrn)
+    else:
+        patient.demographics_set.update(hospital_number=hospital_number)
 
     patient.create_episode(
         category_name=episode_category.display_name,


### PR DESCRIPTION
When using create_rfh_patient_from_hospital_number if the MRN passed in has already been marked as merged in elcid raise a ValueError.

Otherwise if it has been merged upstream, make sure we use the correct MRN.