### PR TITLE
Changes the lab test load to also load lab tests for any merged MRNs

### DIFF
--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -808,18 +808,28 @@ class ProdApi(base_api.BaseApi):
     @timing
     def results_for_hospital_number(self, hospital_number):
         """
-        returns all the results for an MRN
+        Returns all the results for an MRN
         aggregated into labtest: observations([])
+
+        Also checks for alternative MRNs to fetch, due to
+        upstream 0 prefixing or Cerner merges.
         """
-        raw_rows = []
         merged_mrns = list(set(MergedMRN.objects.filter(
             patient__demographics__hospital_number=hospital_number
         ).values_list('mrn', flat=True)))
+
         all_mrns = [hospital_number] + merged_mrns
+        zero_prexixed_mrns = []
+
         for mrn in all_mrns:
-            raw_rows.extend(self.raw_data(mrn))
-            zero_prefixed_mrns = self.query_for_zero_prefixed(mrn)
-            for zero_prefixed_mrn in zero_prefixed_mrns:
-                raw_rows.extend(self.raw_data(zero_prefixed_mrn))
+            zero_prexixed_mrns += self.query_for_zero_prefixed(mrn)
+
+        all_mrns = all_mrns + zero_prexixed_mrns
+
+        raw_rows = []
+
+        for mrn in all_mrns:
+            raw_rows += self.raw_data(mrn)
+
         rows = (PathologyRow(raw_row) for raw_row in raw_rows)
         return self.cast_rows_to_lab_test(rows)

--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -819,12 +819,12 @@ class ProdApi(base_api.BaseApi):
         ).values_list('mrn', flat=True)))
 
         all_mrns = [hospital_number] + merged_mrns
-        zero_prexixed_mrns = []
+        zero_prefixed_mrns = []
 
         for mrn in all_mrns:
-            zero_prexixed_mrns += self.query_for_zero_prefixed(mrn)
+            zero_prefixed_mrns += self.query_for_zero_prefixed(mrn)
 
-        all_mrns = all_mrns + zero_prexixed_mrns
+        all_mrns = all_mrns + zero_prefixed_mrns
         raw_rows = []
 
         for mrn in all_mrns:

--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -825,7 +825,6 @@ class ProdApi(base_api.BaseApi):
             zero_prexixed_mrns += self.query_for_zero_prefixed(mrn)
 
         all_mrns = all_mrns + zero_prexixed_mrns
-
         raw_rows = []
 
         for mrn in all_mrns:

--- a/intrahospital_api/apis/prod_api.py
+++ b/intrahospital_api/apis/prod_api.py
@@ -12,7 +12,7 @@ from pytds.tds import OperationalError
 
 from elcid.models import (
     Demographics, ContactInformation, NextOfKinDetails, GPDetails,
-    MasterFileMeta
+    MasterFileMeta, MergedMRN
 )
 from elcid.utils import timing
 from intrahospital_api.apis import base_api
@@ -811,9 +811,15 @@ class ProdApi(base_api.BaseApi):
         returns all the results for an MRN
         aggregated into labtest: observations([])
         """
-        other_hns = self.query_for_zero_prefixed(hospital_number)
-        raw_rows = self.raw_data(hospital_number)
-        for other_hn in other_hns:
-            raw_rows.extend(self.raw_data(other_hn))
+        raw_rows = []
+        merged_mrns = list(set(MergedMRN.objects.filter(
+            patient__demographics__hospital_number=hospital_number
+        ).values_list('mrn', flat=True)))
+        all_mrns = [hospital_number] + merged_mrns
+        for mrn in all_mrns:
+            raw_rows.extend(self.raw_data(mrn))
+            zero_prefixed_mrns = self.query_for_zero_prefixed(mrn)
+            for zero_prefixed_mrn in zero_prefixed_mrns:
+                raw_rows.extend(self.raw_data(zero_prefixed_mrn))
         rows = (PathologyRow(raw_row) for raw_row in raw_rows)
         return self.cast_rows_to_lab_test(rows)


### PR DESCRIPTION
If an inactive MRN has been merged into an MRN. Make sure we query lab tests with the inactive MRN when looking for lab tests for the active MRN.