### PR TITLE
Changes the imaging loads to work with merged MRNs

### DIFF
--- a/plugins/imaging/loader.py
+++ b/plugins/imaging/loader.py
@@ -5,7 +5,7 @@ import time
 from opal.core import serialization
 from collections import defaultdict
 from django.db import transaction
-from elcid.models import Demographics
+from elcid.models import Demographics, MergedMRN
 from django.db.models import DateTimeField
 from django.utils import timezone
 
@@ -33,10 +33,14 @@ def load_imaging(patient):
     Given a PATIENT, load any upstream imaging reports we do not have
     """
     api = ProdAPI()
-    imaging_rows = api.execute_hospital_query(
-        Q_GET_IMAGING,
-        params={'mrn': patient.demographics().hospital_number}
-    )
+    mrn = patient.demographics_set.all()[0].hospital_number
+    merged_mrns = [i.mrn for i in patient.mergedmrn_set.all()]
+    mrns = [mrn] + merged_mrns
+    imaging_rows = []
+    for mrn in mrns:
+        imaging_rows.extend(api.execute_hospital_query(
+            Q_GET_IMAGING, params={'mrn': mrn}
+        ))
     created = update_imaging_from_query_result(imaging_rows)
     logger.info(
         f'Imaging patient load:Saved {len(created)} for Patient {patient.id}'
@@ -130,6 +134,14 @@ def update_imaging_from_query_result(imaging_rows):
     for demo in demographics:
         hospital_number_to_patients[demo.hospital_number].append(
             demo.patient
+        )
+
+    merged_mrns = MergedMRN.objects.filter(
+        mrn__in=hospital_numbers
+    )
+    for merged_mrn in merged_mrns:
+        hospital_number_to_patients[merged_mrn.mrn].append(
+            merged_mrn.patient
         )
 
     for row in imaging_rows:

--- a/plugins/imaging/tests/test_loader.py
+++ b/plugins/imaging/tests/test_loader.py
@@ -1,0 +1,32 @@
+from opal.core.test import OpalTestCase
+from plugins.imaging import models, loader
+
+class UpdateImagingFromQueryResultTestCase(OpalTestCase):
+	def test_update_patient_imaging_from_query_result(self):
+		imaging_row = {
+			k: None for k in models.Imaging.UPSTREAM_FIELDS_TO_MODEL_FIELDS.keys()
+		}
+		imaging_row["result_id"] = "789"
+		imaging_row["patient_number"] = "123"
+		patient, _ = self.new_patient_and_episode_please()
+		patient.demographics_set.update(hospital_number="123")
+		loader.update_imaging_from_query_result([imaging_row])
+		self.assertEqual(
+			patient.imaging.get().result_id, "789"
+		)
+
+	def test_update_merged_patient_imaging_from_query_result(self):
+		imaging_row = {
+			k: None for k in models.Imaging.UPSTREAM_FIELDS_TO_MODEL_FIELDS.keys()
+		}
+		imaging_row["result_id"] = "789"
+		imaging_row["patient_number"] = "567"
+		patient, _ = self.new_patient_and_episode_please()
+		patient.demographics_set.update(hospital_number="123")
+		patient.mergedmrn_set.create(
+			mrn="567"
+		)
+		loader.update_imaging_from_query_result([imaging_row])
+		self.assertEqual(
+			patient.imaging.get().result_id, "789"
+		)


### PR DESCRIPTION
Changes the imaging load patient to make sure it queries for inactive MRNs related to the patient.

Changes the batch create to attach the patient if the imaging row is using an inactive MRN