### PR TITLE
Changes the appointment load for a patient to also check merged (inactive) MRNs

### DIFF
--- a/plugins/appointments/loader.py
+++ b/plugins/appointments/loader.py
@@ -214,9 +214,15 @@ def load_appointments(patient):
     Load any upstream appointment data we may not have for PATIENT
     """
     api = ProdAPI()
-    demographic = patient.demographics()
-    appointments = api.execute_hospital_query(
-        Q_GET_ALL_PATIENT_APPOINTMENTS,
-        params={'mrn': demographic.hospital_number}
+    mrn = patient.demographics().hospital_number
+    other_mrns = list(
+        patient.mergedmrn_set.values_list('mrn', flat=True)
     )
+    all_mrns = [mrn] + other_mrns
+    appointments = []
+    for mrn in all_mrns:
+        appointments.extend(api.execute_hospital_query(
+            Q_GET_ALL_PATIENT_APPOINTMENTS,
+            params={'mrn': mrn}
+        ))
     update_appointments_from_query_result(appointments)


### PR DESCRIPTION
The MergedMRN table has the inactive MRNs associated with a patient. This change means that when loading appointments we check a patients active and inactive MRNs.