### PR TITLE
Makes get_patients_from_mrns more efficient.

### DIFF
--- a/elcid/utils.py
+++ b/elcid/utils.py
@@ -84,10 +84,14 @@ def natural_keys(text):
 
 def get_patients_from_mrns(mrns):
     """
-    Takes in a list of MRNs.
-    Strips leading zeros.
-    Looks up the MRNs vs Demographics and MergedMRNs.
-    Returns a map of {mrn: patient}
+    Takes in an iterable of MRNs and returns
+    a dictionary of {mrn: patient}.
+
+    When matching MRN to patient:
+    * It looks for patients with those MRNs without any
+    leading zeros the MRN may have.
+    * It removes empty MRNs or MRNs that are only zeros.
+    e.g. 000
     """
     cleaned_mrn_to_mrn = {
         i.strip().lstrip('0'): i for i in mrns if i.strip().lstrip('0')
@@ -107,7 +111,8 @@ def get_patients_from_mrns(mrns):
     for merged_mrn in merged_mrns:
         upstream_mrn = cleaned_mrn_to_mrn[merged_mrn.mrn]
         if upstream_mrn not in result:
-            # It should never be the case that a merged MRN
-            # but just in case
+            # If we have a demographics match
+            # do not used an MergedMRN match
+            # (this should never be the case)
             result[upstream_mrn] = merged_mrn.patient
     return result

--- a/elcid/utils.py
+++ b/elcid/utils.py
@@ -105,14 +105,14 @@ def get_patients_from_mrns(mrns):
         upstream_mrn = cleaned_mrn_to_mrn[demo.hospital_number]
         result[upstream_mrn] = demo.patient
 
+    # If we can't find the cleaned MRN in Demographics, check
+    # the MergedMRN table.
+    other_mrns = set(cleaned_mrn_to_mrn.keys()) - set(result.keys())
     merged_mrns = models.MergedMRN.objects.filter(
-        mrn__in=cleaned_mrn_to_mrn.keys()
+        mrn__in=other_mrns
     ).select_related('patient')
     for merged_mrn in merged_mrns:
         upstream_mrn = cleaned_mrn_to_mrn[merged_mrn.mrn]
         if upstream_mrn not in result:
-            # If we have a demographics match
-            # do not used an MergedMRN match
-            # (this should never be the case)
             result[upstream_mrn] = merged_mrn.patient
     return result


### PR DESCRIPTION
Only look for MRNs in the MergedMRN table if they have not been found in demographics.