### PR TITLE
Makes the LocationHistoryView only visibile by IPC users or superusers

### DIFF
--- a/plugins/admissions/detail.py
+++ b/plugins/admissions/detail.py
@@ -2,6 +2,7 @@
 Custom Detail view to display admissions
 """
 from opal.core import detail
+from plugins.ipc import constants as ipc_constants
 
 
 class AdmissionDetailView(detail.PatientDetailView):
@@ -14,3 +15,14 @@ class LocationHistoryView(detail.PatientDetailView):
     display_name = "Location History"
     order        = 10
     template     = "detail/location_history.html"
+
+    @classmethod
+    def visible_to(klass, user):
+        if user.is_superuser:
+            return True
+        ipc_user = user.profile.roles.filter(
+            name=ipc_constants.IPC_ROLE
+        ).exists()
+        if ipc_user:
+            return True
+        return False

--- a/plugins/admissions/tests/test_views.py
+++ b/plugins/admissions/tests/test_views.py
@@ -1,0 +1,29 @@
+from django.contrib.auth.models import User
+from opal.core.test import OpalTestCase
+from plugins.admissions import detail
+from plugins.ipc import constants as ipc_constants
+
+class LocationHistoryViewVisibilityTestCase(OpalTestCase):
+	def setUp(self):
+		self.view_user = User.objects.create(
+			username="view_user"
+		)
+
+	def test_superuser(self):
+		self.view_user.is_superuser = True
+		self.assertTrue(detail.LocationHistoryView.visible_to(
+			self.view_user
+		))
+
+	def test_ipc(self):
+		self.view_user.profile.roles.create(
+			name=ipc_constants.IPC_ROLE
+		)
+		self.assertTrue(detail.LocationHistoryView.visible_to(
+			self.view_user
+		))
+
+	def test_other_user(self):
+		self.assertFalse(detail.LocationHistoryView.visible_to(
+			self.view_user
+		))


### PR DESCRIPTION
At present the location history view should only be visibile by super users or IPC users.