### PR TITLE
Query for MRNs with zero prefixes when querying discharge summarieso

### DIFF
--- a/plugins/dischargesummary/tests/test_loader.py
+++ b/plugins/dischargesummary/tests/test_loader.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+from opal.core.test import OpalTestCase
+from plugins.dischargesummary import loader
+
+
+@patch('plugins.dischargesummary.loader.ProdAPI')
+class QueryForZeroPrefixedTestCase(OpalTestCase):
+	def test_query_found_zero_prefixed(self, prod_api):
+		prod_api.return_value.execute_hospital_query.return_value = [
+			{"RF1_NUMBER": "00123"}
+		]
+		result = loader.query_for_zero_prefixed('123')
+		self.assertEqual(result, ['00123'])
+
+	def test_flawed_zero_prefixed(self, prod_api):
+		prod_api.return_value.execute_hospital_query.return_value = [
+			{"RF1_NUMBER": "100123"}
+		]
+		result = loader.query_for_zero_prefixed('123')
+		self.assertEqual(result, [])


### PR DESCRIPTION
When looking upstream to see if a patient has discharge summaries query to see they have any with zero prefixes.

In theory this does not matter as the upstream table is archived. In practice it enables us to reload the discharge summaries after we delete leading zeros.