### PR TITLE
Discharge summary loader fix

### DIFF
--- a/plugins/dischargesummary/loader.py
+++ b/plugins/dischargesummary/loader.py
@@ -106,7 +106,12 @@ def load_dischargesummaries(patient):
                         v = timezone.make_aware(v)
                     except AttributeError:
                         # Only some of the "DateTime" fields are typed as such
-                        v = datetime.datetime.strptime(v, '%d/%m/%Y %H:%M:%S')
+                        try:
+                            v = datetime.datetime.strptime(v, '%d/%m/%Y %H:%M:%S')
+                        except ValueError:
+                            # datetime fields are sometimes stored in a different format
+                            # e.g. Sep 20 2021 12:55PM
+                            v = datetime.datetime.strptime(v, '%b %d %Y %I:%M%p')
                         v = timezone.make_aware(v)
 
                 parsed[DischargeSummary.UPSTREAM_FIELDS_TO_MODEL_FIELDS[k]] = v

--- a/plugins/dischargesummary/loader.py
+++ b/plugins/dischargesummary/loader.py
@@ -109,7 +109,7 @@ def load_dischargesummaries(patient):
                         try:
                             v = datetime.datetime.strptime(v, '%d/%m/%Y %H:%M:%S')
                         except ValueError:
-                            # datetime fields are sometimes stored in a different format
+                            # LAST_UPDATED is sometimes stored in a different format
                             # e.g. Sep 20 2021 12:55PM
                             v = datetime.datetime.strptime(v, '%b %d %Y %I:%M%p')
                         v = timezone.make_aware(v)


### PR DESCRIPTION
So discharge summary errors occassionally because there are multiple date formats used for the LAST_UPDATED field in VIEW_ElCid_Freenet_TTA_Main. This change allows for both formats.