### PR TITLE
Make the covid calculator tests use tz aware datetimes

### DIFF
--- a/plugins/covid/tests/test_extract.py
+++ b/plugins/covid/tests/test_extract.py
@@ -1,4 +1,5 @@
 import datetime
+from django.utils import timezone
 from opal.core.test import OpalTestCase
 from plugins.covid import extract
 
@@ -24,9 +25,13 @@ class GetClosestObservationTestCase(OpalTestCase):
         )
 
     def test_multiple_later_dates(self):
-        self.obs_1.observation_datetime = datetime.datetime(2021, 11, 16)
+        self.obs_1.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 16)
+        )
         self.obs_1.save()
-        self.obs_2.observation_datetime = datetime.datetime(2021, 11, 17)
+        self.obs_2.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 17)
+        )
         self.obs_2.save()
         found_obs = extract.get_closest_observation(
             self.patient, 'test_name', 'obs_name', self.followup_date
@@ -34,9 +39,13 @@ class GetClosestObservationTestCase(OpalTestCase):
         self.assertEqual(found_obs.id, self.obs_1.id)
 
     def test_multiple_ealier_dates(self):
-        self.obs_1.observation_datetime = datetime.datetime(2021, 11, 13)
+        self.obs_1.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 13)
+        )
         self.obs_1.save()
-        self.obs_2.observation_datetime = datetime.datetime(2021, 11, 14)
+        self.obs_2.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 14)
+        )
         self.obs_2.save()
         found_obs = extract.get_closest_observation(
             self.patient, 'test_name', 'obs_name', self.followup_date
@@ -44,9 +53,13 @@ class GetClosestObservationTestCase(OpalTestCase):
         self.assertEqual(found_obs.id, self.obs_2.id)
 
     def test_later_date_vs_earlier_date(self):
-        self.obs_1.observation_datetime = datetime.datetime(2021, 11, 13)
+        self.obs_1.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 13)
+        )
         self.obs_1.save()
-        self.obs_2.observation_datetime = datetime.datetime(2021, 11, 16)
+        self.obs_2.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 16)
+        )
         self.obs_2.save()
         found_obs = extract.get_closest_observation(
             self.patient, 'test_name', 'obs_name', self.followup_date
@@ -54,7 +67,9 @@ class GetClosestObservationTestCase(OpalTestCase):
         self.assertEqual(found_obs.id, self.obs_2.id)
 
     def test_on_the_follow_up_date(self):
-        self.obs_1.observation_datetime = datetime.datetime(2021, 11, 15)
+        self.obs_1.observation_datetime = timezone.make_aware(
+            datetime.datetime(2021, 11, 15)
+        )
         self.obs_1.save()
         found_obs = extract.get_closest_observation(
             self.patient, 'test_name', 'obs_name', self.followup_date

--- a/plugins/tb/tests/test_loader.py
+++ b/plugins/tb/tests/test_loader.py
@@ -9,9 +9,11 @@ from plugins.tb import episode_categories
 
 @mock.patch("plugins.tb.loader.create_rfh_patient_from_hospital_number")
 @mock.patch("plugins.tb.loader.ProdAPI")
+@mock.patch("plugins.tb.loader.logger")
 class CreateFollowUpEpisodeTestCase(OpalTestCase):
     def test_create_patient_who_does_not_exist(
         self,
+        logger,
         ProdAPI,
         create_rfh_patient_from_hospital_number
     ):
@@ -43,6 +45,7 @@ class CreateFollowUpEpisodeTestCase(OpalTestCase):
 
     def test_create_episode_which_does_not_exist(
         self,
+        logger,
         ProdAPI,
         create_rfh_patient_from_hospital_number
     ):
@@ -69,6 +72,7 @@ class CreateFollowUpEpisodeTestCase(OpalTestCase):
 
     def test_do_nothing_if_episode_exists(
         self,
+        logger,
         ProdAPI,
         create_rfh_patient_from_hospital_number
     ):


### PR DESCRIPTION
In plugins.covid:
  Use of timezone unaware datetimes creates warnings, so lets not use them in tests and cut down on the noise.
  This only reduces the warning logs from 8 timezone warnings to 3.
  The other 3 warnings are actually created by the code so while fixable have a higher overhead to remove.

In plugins.tb:
 Mock out the info.warnings in the tb loader. These statements are not used or checked in tests.

