### PR TITLE
Changes the toggle for the services drop down to be the whole div

### DIFF
--- a/elcid/templates/partials/services_menu_item.html
+++ b/elcid/templates/partials/services_menu_item.html
@@ -1,8 +1,8 @@
 {% load forms %}
 
-<li uib-dropdown>
+<li uib-dropdown uib-dropdown-toggle id="services-dropdown">
   <a class="pointer">
-  <div uib-dropdown-toggle id="services-dropdown">
+  <div>
     <i class="fa fa-hospital-o"></i>
     Services
     <i class="fa fa-angle-down"></i>


### PR DESCRIPTION
Changes the toggle for the services menu item drop down to be the whole div. Prior to this change if you clicked on the edge of the highlighted box it would not trigger the drop down menu. This changes it so that you can click anywhere within the list item and the drop down will be triggered.