### PR TITLE
Remove sync patients

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -127,25 +127,6 @@ def async_load_patient(patient_id, patient_load_id):
         raise
 
 
-def sync_all_patients():
-    """
-    A utility to go through all patients and
-    sync them where possible.
-
-    This is expected to be called from the shell
-    """
-    patients = Patient.objects.all().prefetch_related("demographics_set")
-    count = patients.count()
-    for number, patient in enumerate(patients):
-        logger.info("Synching {} ({}/{})".format(
-            patient.id, number+1, count
-        ))
-        try:
-            sync_patient(patient)
-        except Exception:
-            log_errors("Unable to sync {}".format(patient.id))
-
-
 def sync_patient(patient):
     hospital_number = patient.demographics_set.all()[0].hospital_number
     results = api.results_for_hospital_number(

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -126,24 +126,6 @@ def async_load_patient(patient_id, patient_load_id):
         log_errors("_load_patient")
         raise
 
-
-def sync_patient(patient):
-    hospital_number = patient.demographics_set.all()[0].hospital_number
-    results = api.results_for_hospital_number(
-        hospital_number
-    )
-    logger.info(
-        "fetched results for patient {}".format(patient.id)
-    )
-    update_lab_tests.update_tests(patient, results)
-    logger.info(
-        "tests synced for {}".format(patient.id)
-    )
-    update_demographics.update_patient_information(patient)
-    logger.info(
-        "patient information synced for {}".format(patient.id)
-    )
-
 @timing
 def _load_patient(patient, patient_load):
     logger.info(

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -288,39 +288,6 @@ class UpdatePatientFromBatchTestCase(ApiTestCase):
         }
 
 
-class SynchPatientTestCase(ApiTestCase):
-    @mock.patch.object(loader.logger, 'info')
-    @mock.patch.object(loader.api, 'results_for_hospital_number')
-    @mock.patch('intrahospital_api.loader.update_lab_tests.update_tests')
-    @mock.patch(
-        'intrahospital_api.loader.update_demographics.update_patient_information'
-    )
-    def test_synch_patient(
-        self, update_patient_information, update_tests, results, info
-    ):
-        patient, _ = self.new_patient_and_episode_please()
-        patient.demographics_set.update(
-            hospital_number="111"
-        )
-        results.return_value = "some_results"
-        loader.sync_patient(patient)
-        results.assert_called_once_with('111')
-        update_tests.assert_called_once_with(patient, "some_results")
-        update_patient_information.assert_called_once_with(patient)
-        self.assertEqual(
-            info.call_args_list[0][0][0],
-            "fetched results for patient {}".format(patient.id)
-        )
-        self.assertEqual(
-            info.call_args_list[1][0][0],
-            "tests synced for {}".format(patient.id)
-        )
-        self.assertEqual(
-            info.call_args_list[2][0][0],
-            "patient information synced for {}".format(patient.id)
-        )
-
-
 class CreateRfhPatientFromHospitalNumberTestCase(OpalTestCase):
     def test_creates_patient_and_episode(self):
         patient = loader.create_rfh_patient_from_hospital_number(

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -288,30 +288,6 @@ class UpdatePatientFromBatchTestCase(ApiTestCase):
         }
 
 
-class SynchAllPatientsTestCase(ApiTestCase):
-    @mock.patch('intrahospital_api.loader.sync_patient')
-    @mock.patch.object(loader.logger, 'info')
-    def test_sync_all_patients(self, info, sync_patient):
-        p, _ = self.new_patient_and_episode_please()
-        loader.sync_all_patients()
-
-        info.assert_called_once_with("Synching {} (1/1)".format(
-            p.id
-        ))
-        sync_patient.assert_called_once_with(p)
-
-    @mock.patch('intrahospital_api.loader.sync_patient')
-    @mock.patch('intrahospital_api.loader.log_errors')
-    @mock.patch.object(loader.logger, 'info')
-    def test_sync_all_patients_with_error(self, info, log_errors, sync_patient):
-        sync_patient.side_effect = ValueError('Boom')
-        patient, _ = self.new_patient_and_episode_please()
-        loader.sync_all_patients()
-        log_errors.assert_called_once_with(
-            "Unable to sync {}".format(patient.id)
-        )
-
-
 class SynchPatientTestCase(ApiTestCase):
     @mock.patch.object(loader.logger, 'info')
     @mock.patch.object(loader.api, 'results_for_hospital_number')


### PR DESCRIPTION
We don't use `sync_all_patients` or `sync_patient`.

`sync_patient` only syncs demographics and lab tests which is probably not what the caller would expect.

`sync_all_patients` would take ages to run and is not wrapped in a transaction so would fail badly when you tried to stop it.