### PR TITLE
Removes the services drop down menu for the time being.

### DIFF
--- a/elcid/__init__.py
+++ b/elcid/__init__.py
@@ -111,7 +111,7 @@ class Application(application.OpalApplication):
         profile = UserProfile.objects.get(user=user)
 
 
-        menu_items.append(ServicesMenuItem(user=user))
+        # menu_items.append(ServicesMenuItem(user=user))
 
 
         return menu_items

--- a/plugins/covid/plugin.py
+++ b/plugins/covid/plugin.py
@@ -20,6 +20,27 @@ class CovidPlugin(plugins.OpalPlugin):
         ]
     }
 
+    @classmethod
+    def get_menu_items(self, user):
+        if not user or not user.is_authenticated:
+            return []
+
+        dashboard = menus.MenuItem(
+            href='/#/covid-19/',
+            display='COVID-19',
+            icon='fa fa-dashboard',
+            activepattern='/#/covid-19/'
+        )
+
+        profile = UserProfile.objects.get(user=user)
+        if profile.roles.filter(name=COVID_ROLE).exists():
+            return [dashboard]
+
+        if user.is_superuser:
+            return [dashboard]
+
+        return []
+
     apis = [
         ('covid_service_test_summary', api.CovidServiceTestSummaryAPI),
         ('covid_cxr', api.CovidCXRViewSet),

--- a/plugins/icu/plugin.py
+++ b/plugins/icu/plugin.py
@@ -4,7 +4,29 @@ Plugin definition for the ICU plugin
 from opal.core import plugins, menus
 from opal.models import UserProfile
 
+from plugins.icu.constants import ICU_ROLE
 from plugins.icu.urls import urlpatterns
 
 class ICUPlugin(plugins.OpalPlugin):
     urls = urlpatterns
+
+    @classmethod
+    def get_menu_items(self, user):
+        if not user or not user.is_authenticated:
+            return []
+
+        dashboard = menus.MenuItem(
+            href='/#/ICU/',
+            display='ICU',
+            icon='fa fa-hospital-o',
+            activepattern='/#/ICU/'
+        )
+
+        profile = UserProfile.objects.get(user=user)
+        if profile.roles.filter(name=ICU_ROLE).exists():
+            return [dashboard]
+
+        if user.is_superuser:
+            return [dashboard]
+
+        return []

--- a/plugins/tb/plugin.py
+++ b/plugins/tb/plugin.py
@@ -41,3 +41,23 @@ class TbPlugin(plugins.OpalPlugin):
         (api.TbTests.basename, api.TbTests,),
         (api.TBAppointments.basename, api.TBAppointments,),
     ]
+
+    @classmethod
+    def get_menu_items(self, user):
+        if not user or not user.is_authenticated:
+            return []
+
+        if not UserProfile.objects.filter(
+            user=user,
+            roles__name=tb_constants.TB_ROLE
+        ).exists:
+            return []
+
+        return [
+            menus.MenuItem(
+                href='/#/tb/clinic-list',
+                display='TB',
+                icon='fa fa-columns',
+                activepattern='/#/tb/clinic-list'
+            )
+        ]


### PR DESCRIPTION
Although it works without issue on the test server, clicking the menu items on production does not work. They do work if you select to open them in a new tag. Further investigation is needed, I'm removing this for the time being.