### PR TITLE
Fixes the discharge summary for cases when some fields are None

### DIFF
--- a/plugins/dischargesummary/loader.py
+++ b/plugins/dischargesummary/loader.py
@@ -91,8 +91,12 @@ def load_dischargesummaries(patient):
             params={'tta_id': summary['SQL_Internal_ID']}
         )
 
-
-        parsed = {}
+        # We expect these fields should be filled in
+        # however this is now always the case.
+        parsed = {
+            "date_of_admission": None,
+            "date_of_discharge": None
+        }
         for k, v in summary.items():
             if v: # Ignore empty values
 


### PR DESCRIPTION
The discharge summary loader assumed the existence of the keys for date_of_admission and date_of_discharge. In some cases these are not set by the upstream data.