### PR TITLE
1071 with services menu

### DIFF
--- a/elcid/__init__.py
+++ b/elcid/__init__.py
@@ -111,7 +111,7 @@ class Application(application.OpalApplication):
         profile = UserProfile.objects.get(user=user)
 
 
-        # menu_items.append(ServicesMenuItem(user=user))
+        menu_items.append(ServicesMenuItem(user=user))
 
 
         return menu_items

--- a/elcid/templates/partials/services_menu_item.html
+++ b/elcid/templates/partials/services_menu_item.html
@@ -1,14 +1,13 @@
 {% load forms %}
 
-<li uib-dropdown uib-dropdown-toggle id="services-dropdown">
-  <a class="pointer">
-  <div>
-    <i class="fa fa-hospital-o"></i>
-    Services
-    <i class="fa fa-angle-down"></i>
-  </div>
+<li uib-dropdown>
+  <a uib-dropdown-toggle class="pointer" id="services-dropdown">
+    <div>
+      <i class="fa fa-hospital-o"></i>
+      Services
+      <i class="fa fa-angle-down"></i>
+    </div>
   </a>
-
   <ul class="uib-dropdown-menu slides" role="menu" aria-labelledby="services-dropdown">
     {% for service in item %}
     <li class="services-dropdown-item">

--- a/plugins/covid/plugin.py
+++ b/plugins/covid/plugin.py
@@ -20,27 +20,6 @@ class CovidPlugin(plugins.OpalPlugin):
         ]
     }
 
-    @classmethod
-    def get_menu_items(self, user):
-        if not user or not user.is_authenticated:
-            return []
-
-        dashboard = menus.MenuItem(
-            href='/#/covid-19/',
-            display='COVID-19',
-            icon='fa fa-dashboard',
-            activepattern='/#/covid-19/'
-        )
-
-        profile = UserProfile.objects.get(user=user)
-        if profile.roles.filter(name=COVID_ROLE).exists():
-            return [dashboard]
-
-        if user.is_superuser:
-            return [dashboard]
-
-        return []
-
     apis = [
         ('covid_service_test_summary', api.CovidServiceTestSummaryAPI),
         ('covid_cxr', api.CovidCXRViewSet),

--- a/plugins/icu/plugin.py
+++ b/plugins/icu/plugin.py
@@ -4,29 +4,7 @@ Plugin definition for the ICU plugin
 from opal.core import plugins, menus
 from opal.models import UserProfile
 
-from plugins.icu.constants import ICU_ROLE
 from plugins.icu.urls import urlpatterns
 
 class ICUPlugin(plugins.OpalPlugin):
     urls = urlpatterns
-
-    @classmethod
-    def get_menu_items(self, user):
-        if not user or not user.is_authenticated:
-            return []
-
-        dashboard = menus.MenuItem(
-            href='/#/ICU/',
-            display='ICU',
-            icon='fa fa-hospital-o',
-            activepattern='/#/ICU/'
-        )
-
-        profile = UserProfile.objects.get(user=user)
-        if profile.roles.filter(name=ICU_ROLE).exists():
-            return [dashboard]
-
-        if user.is_superuser:
-            return [dashboard]
-
-        return []

--- a/plugins/tb/plugin.py
+++ b/plugins/tb/plugin.py
@@ -41,23 +41,3 @@ class TbPlugin(plugins.OpalPlugin):
         (api.TbTests.basename, api.TbTests,),
         (api.TBAppointments.basename, api.TBAppointments,),
     ]
-
-    @classmethod
-    def get_menu_items(self, user):
-        if not user or not user.is_authenticated:
-            return []
-
-        if not UserProfile.objects.filter(
-            user=user,
-            roles__name=tb_constants.TB_ROLE
-        ).exists:
-            return []
-
-        return [
-            menus.MenuItem(
-                href='/#/tb/clinic-list',
-                display='TB',
-                icon='fa fa-columns',
-                activepattern='/#/tb/clinic-list'
-            )
-        ]


### PR DESCRIPTION
We had an issue that clicking on the dropdown elements in the services
menu did not change the page. This is because the uib-dropdown-toggle
was overriding all links so that they toggled the menu. This resolves
this by moving the dropdown toggle to the <a> which does not encompass
the rest of the menu.