### PR TITLE
Reject any attempt to hit the server which are not our allowed hosts servers

### DIFF
--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -5,7 +5,7 @@ log_format timed_combined escape=json '$remote_addr - $remote_user [$time_local]
 
 server {
     listen 80;
-    server_name "";
+    server_name 192.168.21.202 elcid-rfh elcid 192.168.21.203 elcid-rfh-test;
     server_name elcid-rfh-test.openhealthcare.org.uk;
     access_log /usr/lib/ohc/log/nginx.log timed_combined;
 
@@ -25,7 +25,16 @@ server {
     }
 
     location /protected {
-         internal;
-         alias /;
+            internal;
+            alias /;
     }
-  }
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    location / {
+        return 400;
+    }
+}

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -6,7 +6,6 @@ log_format timed_combined escape=json '$remote_addr - $remote_user [$time_local]
 server {
     listen 80;
     server_name 192.168.21.202 elcid-rfh elcid 192.168.21.203 elcid-rfh-test;
-    server_name elcid-rfh-test.openhealthcare.org.uk;
     access_log /usr/lib/ohc/log/nginx.log timed_combined;
 
     location /himunin {


### PR DESCRIPTION
So this returns a 400 error if its not one of `192.168.21.202 elcid-rfh elcid 192.168.21.203 elcid-rfh-test;`

400 error because that's what django returns if its not in the allowed hosts.

I'm not including the full domain at this time as it will be one line change to do it next time and otherwise we need to change our allowed hosts. (I don't think we're supporting it at this stage right?)