### PR TITLE
Adds a management command to disable all users on apart from hard coded ones

### DIFF
--- a/elcid/management/commands/disable_non_test_users.py
+++ b/elcid/management/commands/disable_non_test_users.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User
+
+test_users = [
+    "ohc", "emmanuel.wey"
+]
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        User.objects.exclude(username__in=test_users).update(
+            is_active=False
+        )

--- a/elcid/test/test_disable_non_test_users.py
+++ b/elcid/test/test_disable_non_test_users.py
@@ -1,0 +1,22 @@
+from opal.core.test import OpalTestCase
+from django.contrib.auth.models import User
+from elcid.management.commands.disable_non_test_users import Command
+
+
+class DisableNonTestUsersTestCase(OpalTestCase):
+    def setUp(self):
+        self.cmd = Command()
+
+    def test_disables_users(self):
+        User.objects.create(username='someone')
+        self.cmd.handle()
+        self.assertFalse(
+            User.objects.get(username='someone').is_active
+        )
+
+    def test_except_certain_users(self):
+        User.objects.create(username='ohc')
+        self.cmd.handle()
+        self.assertTrue(
+            User.objects.get(username='ohc').is_active
+        )


### PR DESCRIPTION
On test we want to sometimes allow normal users to try out the test server. To stop any confusion these users should be deactived later.