### PR TITLE
168 disallow multiple user email addresses

### DIFF
--- a/elcid/admin.py
+++ b/elcid/admin.py
@@ -15,8 +15,8 @@ admin.site.unregister(User)
 
 
 class ElcidUserAdmin(opal_admin.UserProfileAdmin):
-	form = forms.ElcidUserAdminChangeForm
-	add_form = forms.ElcidUserAdminCreationForm
+    form = forms.ElcidUserAdminChangeForm
+    add_form = forms.ElcidUserAdminCreationForm
 
 admin.site.register(User, ElcidUserAdmin)
 

--- a/elcid/admin.py
+++ b/elcid/admin.py
@@ -1,12 +1,13 @@
 """
 Admin for elCID models
 """
+from django import forms as django_forms
 from django.contrib.auth.models import User
 from django.contrib import admin
 from reversion.admin import VersionAdmin
 from opal import admin as opal_admin
-from django.contrib.auth.admin import UserAdmin
-from elcid import forms
+from django.contrib.auth import forms as user_forms
+from django.contrib.auth.models import User
 
 from elcid.models import BloodCultureIsolate
 
@@ -14,9 +15,41 @@ from elcid.models import BloodCultureIsolate
 admin.site.unregister(User)
 
 
+class ElcidUserAdminCreationForm(user_forms.UserCreationForm):
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        if len(email) == 0:
+            return email
+        existing_user = User.objects.filter(
+            email=email
+        ).first()
+        if existing_user is not None:
+            raise django_forms.ValidationError(
+                f"Email is currently in use by {existing_user.username}"
+            )
+        return email
+
+
+class ElcidUserAdminChangeForm(user_forms.UserChangeForm):
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        if len(email) == 0:
+            return email
+        existing_user = User.objects.exclude(
+            id=self.instance.id
+        ).filter(
+            email=email
+        ).first()
+        if existing_user:
+            raise django_forms.ValidationError(
+                f"Email is currently in use by {existing_user.username}"
+            )
+        return email
+
+
 class ElcidUserAdmin(opal_admin.UserProfileAdmin):
-    form = forms.ElcidUserAdminChangeForm
-    add_form = forms.ElcidUserAdminCreationForm
+    form = ElcidUserAdminChangeForm
+    add_form = ElcidUserAdminCreationForm
 
 admin.site.register(User, ElcidUserAdmin)
 

--- a/elcid/admin.py
+++ b/elcid/admin.py
@@ -1,10 +1,24 @@
 """
 Admin for elCID models
 """
+from django.contrib.auth.models import User
 from django.contrib import admin
 from reversion.admin import VersionAdmin
+from opal import admin as opal_admin
+from django.contrib.auth.admin import UserAdmin
+from elcid import forms
 
 from elcid.models import BloodCultureIsolate
+
+
+admin.site.unregister(User)
+
+
+class ElcidUserAdmin(opal_admin.UserProfileAdmin):
+	form = forms.ElcidUserAdminChangeForm
+	add_form = forms.ElcidUserAdminCreationForm
+
+admin.site.register(User, ElcidUserAdmin)
 
 
 admin.site.register(BloodCultureIsolate, VersionAdmin)

--- a/elcid/forms.py
+++ b/elcid/forms.py
@@ -1,10 +1,44 @@
 """
 Forms for eLCID
 """
+from django.contrib.auth.models import User
 from django import forms
+from django.contrib.auth import forms as user_forms
 
 class BulkCreateUsersForm(forms.Form):
     """
     Form for uploading a CSV of users to add.
     """
     users = forms.FileField()
+
+
+class ElcidUserAdminCreationForm(user_forms.UserCreationForm):
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        if len(email) == 0:
+            return email
+        existing_user = User.objects.filter(
+            email=email
+        ).first()
+        if existing_user is not None:
+            raise forms.ValidationError(
+                f"Email is currently in use by {existing_user.username}"
+            )
+        return email
+
+
+class ElcidUserAdminChangeForm(user_forms.UserChangeForm):
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        if len(email) == 0:
+            return email
+        existing_user = User.objects.exclude(
+            id=self.instance.id
+        ).filter(
+            email=email
+        ).first()
+        if existing_user:
+            raise forms.ValidationError(
+                f"Email is currently in use by {existing_user.username}"
+            )
+        return email

--- a/elcid/forms.py
+++ b/elcid/forms.py
@@ -1,44 +1,11 @@
 """
 Forms for eLCID
 """
-from django.contrib.auth.models import User
 from django import forms
-from django.contrib.auth import forms as user_forms
+
 
 class BulkCreateUsersForm(forms.Form):
     """
     Form for uploading a CSV of users to add.
     """
     users = forms.FileField()
-
-
-class ElcidUserAdminCreationForm(user_forms.UserCreationForm):
-    def clean_email(self):
-        email = self.cleaned_data.get('email')
-        if len(email) == 0:
-            return email
-        existing_user = User.objects.filter(
-            email=email
-        ).first()
-        if existing_user is not None:
-            raise forms.ValidationError(
-                f"Email is currently in use by {existing_user.username}"
-            )
-        return email
-
-
-class ElcidUserAdminChangeForm(user_forms.UserChangeForm):
-    def clean_email(self):
-        email = self.cleaned_data.get('email')
-        if len(email) == 0:
-            return email
-        existing_user = User.objects.exclude(
-            id=self.instance.id
-        ).filter(
-            email=email
-        ).first()
-        if existing_user:
-            raise forms.ValidationError(
-                f"Email is currently in use by {existing_user.username}"
-            )
-        return email

--- a/elcid/forms.py
+++ b/elcid/forms.py
@@ -3,7 +3,6 @@ Forms for eLCID
 """
 from django import forms
 
-
 class BulkCreateUsersForm(forms.Form):
     """
     Form for uploading a CSV of users to add.

--- a/elcid/test/test_admin.py
+++ b/elcid/test/test_admin.py
@@ -1,0 +1,178 @@
+from opal.core.test import OpalTestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+from opal.models import Role
+
+class ElcidUserAdminFormTestCase(OpalTestCase):
+    """
+    Elcid overwrites the opal user admin to make sure that
+    we can't have duplicate emails.
+
+    This unit test also checks that the opal user profile
+    logic still works, ie that we have inheritance set up
+    correctly.
+    """
+    def setUp(self):
+        # initialise the property
+        self.user
+        self.assertTrue(
+            self.client.login(
+                username=self.USERNAME,
+                password=self.PASSWORD
+            )
+        )
+        self.new_user = User.objects.create(username="test_user")
+        self.new_user.set_password("test1")
+        self.new_user.save()
+        self.add_url = reverse('admin:auth_user_add')
+        self.change_url = reverse(
+            'admin:auth_user_change', args=(self.new_user.pk,)
+        )
+        self.role = Role.objects.create(name="can_doctor")
+
+
+    def test_post_create_user_success(self):
+        """
+        Tests that we can create a user and user profile
+        """
+        post_dict = {
+            # profile fields
+             '_save': ['Save'],
+            'profile-MIN_NUM_FORMS': ['0'],
+            'profile-TOTAL_FORMS': ['1'],
+            'profile-MAX_NUM_FORMS': ['1'],
+            'profile-__prefix__-id': [''],
+            'profile-0-id': [''],
+            'profile-0-roles': [self.role.id],
+            'profile-0-user': [''],
+            'profile-INITIAL_FORMS': ['0'],
+            'profile-__prefix__-force_password_change': ['on'],
+
+            # user fields
+            'username': ['create_user'],
+            'email': ['some_email@nhs.com'],
+            'password1': ['test1'],
+            'password2': ['test1'],
+            'first_name': [''],
+            'last_name': [''],
+        }
+        self.client.post(self.add_url, post_dict)
+        new_user = User.objects.filter(username='create_user').first()
+        # a user should have been created
+        self.assertIsNotNone(new_user)
+        # the user's user profile should have the role can_doctor
+        self.assertEqual(
+            list(new_user.profile.roles.values_list('name', flat=True)),
+            ["can_doctor"]
+        )
+
+    def test_post_create_user_email_error(self):
+        post_dict = {
+            # profile fields
+             '_save': ['Save'],
+            'profile-MIN_NUM_FORMS': ['0'],
+            'profile-TOTAL_FORMS': ['1'],
+            'profile-MAX_NUM_FORMS': ['1'],
+            'profile-__prefix__-id': [''],
+            'profile-0-id': [''],
+            'profile-0-roles': [self.role.id],
+            'profile-0-user': [''],
+            'profile-INITIAL_FORMS': ['0'],
+            'profile-__prefix__-force_password_change': ['on'],
+
+            # user fields
+            'username': ['create_user'],
+            'email': ['someone@nhs.net'],
+            'password1': ['test1'],
+            'password2': ['test1'],
+            'first_name': [''],
+            'last_name': [''],
+        }
+        User.objects.create(
+            username='existing_user', email='someone@nhs.net'
+        )
+
+        new_user = User.objects.filter(username='create_user').first()
+        response = self.client.post(self.add_url, post_dict)
+        self.assertEqual(
+            response.context['adminform'].errors,
+            {'email': ['Email is currently in use by existing_user']}
+        )
+        # a user should have been created
+        self.assertIsNone(new_user)
+
+    def test_post_edit_user_success(self):
+        post_dict = {
+            '_save': ['Save'],
+            'first_name': [''],
+            'username': ['edit_user'],
+            'password1': ['test1'],
+            'password2': ['test1'],
+            'last_name': [''],
+            'email': [''],
+            'last_login_0': [''],
+            'last_login_1': [''],
+            'date_joined_0': ['02/08/2019'],
+            'date_joined_1': ['14:21:00'],
+            'initial-date_joined_0': ['02/08/2019'],
+            'initial-date_joined_1': ['14:21:00'],
+            'is_active': ['on'],
+            'profile-TOTAL_FORMS': ['1'],
+            'profile-MAX_NUM_FORMS': ['1'],
+            'profile-INITIAL_FORMS': ['1'],
+            'profile-__prefix__-id': [''],
+            'profile-__prefix__-user': [self.new_user.pk],
+            'profile-0-force_password_change': ['on'],
+            'profile-0-id': [self.new_user.profile.id],
+            'profile-0-user': [self.new_user.id],
+            'profile-0-roles': [self.role.id],
+            'profile-__prefix__-force_password_change': ['on'],
+            'profile-MIN_NUM_FORMS': ['0'],
+        }
+        self.client.post(self.change_url, post_dict)
+        reloaded_user = User.objects.get(username="edit_user")
+        self.assertEqual(
+            list(reloaded_user.profile.roles.values_list('name', flat=True)),
+            ["can_doctor"]
+        )
+
+    def test_post_edit_user_email_error(self):
+        User.objects.create(
+            username='existing_user', email='someone@nhs.net'
+        )
+
+        post_dict = {
+            '_save': ['Save'],
+            'first_name': [''],
+            'username': ['edit_user'],
+            'password1': ['test1'],
+            'password2': ['test1'],
+            'last_name': [''],
+            'email': ['someone@nhs.net'],
+            'last_login_0': [''],
+            'last_login_1': [''],
+            'date_joined_0': ['02/08/2019'],
+            'date_joined_1': ['14:21:00'],
+            'initial-date_joined_0': ['02/08/2019'],
+            'initial-date_joined_1': ['14:21:00'],
+            'is_active': ['on'],
+            'profile-TOTAL_FORMS': ['1'],
+            'profile-MAX_NUM_FORMS': ['1'],
+            'profile-INITIAL_FORMS': ['1'],
+            'profile-__prefix__-id': [''],
+            'profile-__prefix__-user': [self.new_user.pk],
+            'profile-0-force_password_change': ['on'],
+            'profile-0-id': [self.new_user.profile.id],
+            'profile-0-user': [self.new_user.id],
+            'profile-0-roles': [self.role.id],
+            'profile-__prefix__-force_password_change': ['on'],
+            'profile-MIN_NUM_FORMS': ['0'],
+        }
+        new_user = User.objects.filter(username='edit_user').first()
+        response = self.client.post(self.add_url, post_dict)
+        self.assertEqual(
+            response.context['adminform'].errors,
+            {'email': ['Email is currently in use by existing_user']}
+        )
+        # a user should have been created
+        self.assertIsNone(new_user)

--- a/plugins/covid/management/commands/create_covid_user.py
+++ b/plugins/covid/management/commands/create_covid_user.py
@@ -25,6 +25,11 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
 
         email = kwargs['email']
+        existing_user = User.objects.filter(email=email).first()
+        if existing_user is not None:
+            raise ValueError(
+                f"Email is currently in use by {existing_user.username}"
+            )
         username, _ = email.split('@')
 
         user = User(username=username)

--- a/plugins/covid/tests/test_create_covid_user.py
+++ b/plugins/covid/tests/test_create_covid_user.py
@@ -1,0 +1,35 @@
+from unittest import mock
+from django.contrib.auth.models import User
+from opal.core.test import OpalTestCase
+from opal import models as opal_models
+from plugins.covid.management.commands import create_covid_user
+
+@mock.patch(
+	'plugins.covid.management.commands.create_covid_user.send_mail'
+)
+class CreateCovidUserTestCase(OpalTestCase):
+	def setUp(self):
+		self.cmd = create_covid_user.Command()
+		for role_name in ['view_lab_tests_in_list', 'view_lab_tests_in_detail', 'view_lab_test_trends', 'covid19']:
+			opal_models.Role.objects.create(name=role_name)
+
+	def test_creates_user(self, send_mail):
+		self.cmd.handle(email="someone@nhs.net")
+		user = User.objects.get(email="someone@nhs.net")
+		self.assertEqual(user.first_name, "someone")
+		self.assertEqual(user.username, "someone")
+		self.assertTrue(user.profile.force_password_change)
+		self.assertTrue(send_mail.called)
+		self.assertEqual(
+			set(user.profile.roles.values_list('name', flat=True)),
+			set(['view_lab_tests_in_list', 'view_lab_tests_in_detail', 'view_lab_test_trends', 'covid19'])
+		)
+
+	def test_fails_on_duplicate_email(self, send_mail):
+		User.objects.create(username="someone_else", email="someone@nhs.net")
+		with self.assertRaises(ValueError):
+			self.cmd.handle(email="someone@nhs.net")
+		self.assertFalse(
+			User.objects.exclude(username="someone_else").exists()
+		)
+		self.assertFalse(send_mail.called)

--- a/plugins/covid/tests/test_create_covid_user.py
+++ b/plugins/covid/tests/test_create_covid_user.py
@@ -11,7 +11,7 @@ class CreateCovidUserTestCase(OpalTestCase):
 	def setUp(self):
 		self.cmd = create_covid_user.Command()
 		for role_name in ['view_lab_tests_in_list', 'view_lab_tests_in_detail', 'view_lab_test_trends', 'covid19']:
-			opal_models.Role.objects.create(name=role_name)
+			opal_models.Role.objects.get_or_create(name=role_name)
 
 	def test_creates_user(self, send_mail):
 		self.cmd.handle(email="someone@nhs.net")


### PR DESCRIPTION
Changes the admin user form to raise an error if a user is added with the same email as a preexisting user.
Changes create_covid_user to raise an error if a user is added with the same email as a preexisting user.

<img width="1393" alt="Screenshot 2023-03-08 at 13 43 17" src="https://user-images.githubusercontent.com/2175455/223728947-cf81cda3-10ee-45da-b9d0-d3e9f8b30058.png">
