### PR TITLE
Makes the error for multiple active mrns clearer

### DIFF
--- a/intrahospital_api/test/test_update_demographics.py
+++ b/intrahospital_api/test/test_update_demographics.py
@@ -673,7 +673,7 @@ class GetActiveMrnAndMergedMrnDataTestCase(OpalTestCase):
         self.assertEqual(active_mrn, "123")
         self.assertEqual(merged_data, [])
         logger.error.assert_called_once_with(
-            "Merge exception raised for 123 with 'Multiple active related MRNs found for 123'"
+            "Merge exception raised for 123 with 'Multiple active related MRNs (123, 234) found for 123'"
         )
 
     @mock.patch('intrahospital_api.update_demographics.get_masterfile_row')

--- a/intrahospital_api/update_demographics.py
+++ b/intrahospital_api/update_demographics.py
@@ -272,7 +272,7 @@ def parse_merge_comments(initial_mrn):
                     active_mrn = next_mrn
                 else:
                     raise MergeException(
-                        f'Multiple active related MRNs found for {initial_mrn}'
+                        f'Multiple active related MRNs ({active_mrn}, {next_mrn}) found for {initial_mrn}'
                     )
             else:
                 inactive_mrn_dicts.append({'mrn': next_mrn, 'merge_comments': merge_comments })


### PR DESCRIPTION
We were not stating the multiple active MRNs in the multiple active MRN message. Lets do that to make it clearer.