### PR TITLE
Ipc logging

### DIFF
--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -331,6 +331,11 @@ LOGGING = {
             'level': 'INFO',
             'propagate': True,
         },
+        'ipc': {
+            'handlers': ['console_detailed', 'mail_admins'],
+            'level': 'INFO',
+            'propagate': True,
+        },
         'labtests': {
             'handlers': ['console_detailed', 'mail_admins'],
             'level': 'INFO',

--- a/plugins/ipc/__init__.py
+++ b/plugins/ipc/__init__.py
@@ -1,3 +1,6 @@
 """
 IPC module for elCID
 """
+import logging
+
+logger = logging.getLogger('ipc')

--- a/plugins/ipc/management/commands/load_ipc_status.py
+++ b/plugins/ipc/management/commands/load_ipc_status.py
@@ -6,6 +6,7 @@ We do not expect this to happen multiple times so the logic
 is just in this management command
 """
 import datetime
+import traceback
 from django.db import transaction
 from django.db.models.fields import BooleanField, DateField
 from django.core.management.base import BaseCommand
@@ -15,6 +16,7 @@ from intrahospital_api import loader
 from elcid.utils import find_patients_from_mrns
 from elcid import episode_categories as elcid_episode_categories
 from plugins.ipc.models import IPCStatus
+from plugins.ipc import logger
 
 
 # We are not storing the fields below
@@ -78,55 +80,60 @@ SELECT * FROM ElCid_Infection_Prevention_Control_View
 class Command(BaseCommand):
     @transaction.atomic
     def handle(self, *args, **options):
-        api = ProdAPI()
+        try:
+            api = ProdAPI()
 
-        updated_by = User.objects.filter(username='ohc').first()
+            updated_by = User.objects.filter(username='ohc').first()
 
-        upstream_result = api.execute_hospital_query(QUERY)
-        self.stdout.write("Query complete")
+            upstream_result = api.execute_hospital_query(QUERY)
+            self.stdout.write("Query complete")
 
-        mrn_to_ipc_patients = find_patients_from_mrns(
-            i['Patient_Number'] for i in upstream_result
-        )
+            mrn_to_ipc_patients = find_patients_from_mrns(
+                i['Patient_Number'] for i in upstream_result
+            )
 
-        for row in upstream_result:
-            patient = mrn_to_ipc_patients.get(row['Patient_Number'])
+            for row in upstream_result:
+                patient = mrn_to_ipc_patients.get(row['Patient_Number'])
 
-            # There will not be a patient if the patient is
-            # not in elcid or if the MRN is invalid
-            # ie empty or only made up of spaces and zeros
-            if not patient:
-                mrn = row['Patient_Number'].lstrip('0')
-                if len(mrn) == 0:
-                    continue
-                else:
-                    patient = loader.create_rfh_patient_from_hospital_number(
-                        mrn, elcid_episode_categories.InfectionService
-                    )
-
-            if patient.episode_set.filter(category_name='IPC').count() == 0:
-                patient.create_episode(category_name='IPC')
-
-            status = patient.ipcstatus_set.all()[0]
-
-            update_dict = {v: row[k] for k, v in MAPPING.items()}
-
-            status.created_by_id = updated_by.id
-
-            for key, value in update_dict.items():
-
-                if isinstance(IPCStatus._meta.get_field(key), DateField):
-
-                    if value == '':
-                        value = None
-                    elif isinstance(value, str):
-                        value = datetime.datetime.strptime(value, '%d/%m/%Y').date()
-
-                if isinstance(IPCStatus._meta.get_field(key), BooleanField):
-                    if value:
-                        value = True
+                # There will not be a patient if the patient is
+                # not in elcid or if the MRN is invalid
+                # ie empty or only made up of spaces and zeros
+                if not patient:
+                    mrn = row['Patient_Number'].lstrip('0')
+                    if len(mrn) == 0:
+                        continue
                     else:
-                        value = False
+                        patient = loader.create_rfh_patient_from_hospital_number(
+                            mrn, elcid_episode_categories.InfectionService
+                        )
 
-                setattr(status, key, value)
-            status.save()
+                if patient.episode_set.filter(category_name='IPC').count() == 0:
+                    patient.create_episode(category_name='IPC')
+
+                status = patient.ipcstatus_set.all()[0]
+
+                update_dict = {v: row[k] for k, v in MAPPING.items()}
+
+                status.created_by_id = updated_by.id
+
+                for key, value in update_dict.items():
+
+                    if isinstance(IPCStatus._meta.get_field(key), DateField):
+
+                        if value == '':
+                            value = None
+                        elif isinstance(value, str):
+                            value = datetime.datetime.strptime(value, '%d/%m/%Y').date()
+
+                    if isinstance(IPCStatus._meta.get_field(key), BooleanField):
+                        if value:
+                            value = True
+                        else:
+                            value = False
+
+                    setattr(status, key, value)
+                status.save()
+        except Exception:
+            msg = f'Exception loading IPC status \n {traceback.format_exc()}'
+            logger.error(msg)
+            raise


### PR DESCRIPTION
IPC at present does no logging. This adds the logging.

load_ipc_status does not send any emails if it fails. This changes the mgmt command to email if it does fail.

**Potentially contentious** At the moment there is an MRN in this table that is not present in the cerner table. I have changed the command to email in this case and carry on. Is this what we want? The alternative is that we create a non RFH patient but my assumption is that this is an error in the ipc status and therefore we should just skip them.

