### PR TITLE
Changes elcid utils to handle None as an MRN

### DIFF
--- a/elcid/test/test_utils.py
+++ b/elcid/test/test_utils.py
@@ -60,6 +60,8 @@ class FindPatientsFromMRNsTestCase(OpalTestCase):
         self.patient.demographics_set.update(
             hospital_number=""
         )
+        result = utils.find_patients_from_mrns([None])
+        self.assertEqual(result, {})
         result = utils.find_patients_from_mrns([""])
         self.assertEqual(result, {})
         result = utils.find_patients_from_mrns(["000"])

--- a/elcid/utils.py
+++ b/elcid/utils.py
@@ -85,7 +85,7 @@ def find_patients_from_mrns(mrns):
     """
     Takes in an iterable of MRNs and returns
     a dictionary of {mrn: patient}.
-    
+
     MRNs that do not match to a patient are silently ignored.
 
     When matching MRN to patient:
@@ -96,7 +96,7 @@ def find_patients_from_mrns(mrns):
     e.g. 000 will be removed.
     """
     cleaned_mrn_to_mrn = {
-        i.strip().lstrip('0'): i for i in mrns if i.strip().lstrip('0')
+        i.strip().lstrip('0'): i for i in mrns if i and i.strip().lstrip('0')
     }
     result = {}
     demos = models.Demographics.objects.filter(


### PR DESCRIPTION
In the bed status table one of the MRNs is marked as None. We should handle this without raising an exception as its no different from an empty string MRN.