### PR TITLE
Makes the bed status loader not create patients with empty MRNs

### DIFF
--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -314,9 +314,10 @@ def load_bed_status():
 
     for mrn in mrns:
         if mrn not in mrn_to_patient:
-            mrn_to_patient[mrn] = create_rfh_patient_from_hospital_number(
-                mrn, InfectionService
-            )
+            if mrn and mrn.strip("0").strip():
+                mrn_to_patient[mrn] = create_rfh_patient_from_hospital_number(
+                    mrn, InfectionService
+                )
 
     with transaction.atomic():
 

--- a/plugins/admissions/tests/test_loader.py
+++ b/plugins/admissions/tests/test_loader.py
@@ -72,6 +72,16 @@ class LoadBedStatusTestCase(OpalTestCase):
             bed_status.patient, patient
         )
 
+    def test_load_bed_status_does_not_create_patients_with_empty_mrns(self, prod_api, create_rfh_patient_from_hospital_number):
+        self.bed_status_row["Local_Patient_Identifier"] = ""
+        prod_api.return_value.execute_warehouse_query.return_value =[
+            self.bed_status_row
+        ]
+        loader.load_bed_status()
+        self.assertFalse(
+            create_rfh_patient_from_hospital_number.called
+        )
+
     def test_load_bed_status_existing_patient(self, prod_api, create_rfh_patient_from_hospital_number):
         patient, _ = self.new_patient_and_episode_please()
         patient.demographics_set.update(


### PR DESCRIPTION
The bed status loader should not create create patients with empty MRNs or with empty string