### PR TITLE
Explicit error messages

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -67,10 +67,10 @@ def create_rfh_patient_from_hospital_number(
         )
 
     if emodels.Demographics.objects.filter(hospital_number=hospital_number).exists():
-        raise ValueError('Patient with this hospital number already exists')
+        raise ValueError(f'Patient with MRN {hospital_number} already exists')
 
     if emodels.MergedMRN.objects.filter(mrn=hospital_number).exists():
-        raise ValueError('MRN has already been merged into another MRN')
+        raise ValueError(f'MRN {hospital_number} has already been merged into another MRN')
 
     if rfh_patient:
         active_mrn, merged_mrn_dicts = update_demographics.get_active_mrn_and_merged_mrn_data(

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -67,7 +67,7 @@ def create_rfh_patient_from_hospital_number(
         )
 
     if emodels.Demographics.objects.filter(hospital_number=hospital_number).exists():
-        raise ValueError(f'Patient with MRN {hospital_number} already exists')
+        raise ValueError(f'A patient with MRN {hospital_number} already exists')
 
     if emodels.MergedMRN.objects.filter(mrn=hospital_number).exists():
         raise ValueError(f'MRN {hospital_number} has already been merged into another MRN')

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -344,7 +344,7 @@ class CreateRfhPatientFromHospitalNumberTestCase(OpalTestCase):
             )
         self.assertEqual(
             str(v.exception),
-            "MRN has already been merged into another MRN"
+            "MRN 111 has already been merged into another MRN"
         )
         self.assertFalse(load_patient.called)
 

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -330,6 +330,28 @@ class CreateRfhPatientFromHospitalNumberTestCase(OpalTestCase):
         self.assertEqual(str(v.exception), expected)
         self.assertFalse(load_patient.called)
 
+    def test_erors_if_the_hospital_number_is_already_assigned(self, load_patient):
+        """
+        The MRN is already in use by a patient
+        """
+        patient, _ = self.new_patient_and_episode_please()
+        patient.demographics_set.update(
+            hospital_number="111"
+        )
+        patient.mergedmrn_set.create(
+            mrn="111"
+        )
+        with self.assertRaises(ValueError) as v:
+            loader.create_rfh_patient_from_hospital_number(
+                '111', episode_categories.InfectionService
+            )
+        self.assertEqual(
+            str(v.exception),
+            "A patient with MRN 111 already exists"
+        )
+        self.assertFalse(load_patient.called)
+
+
     def test_errors_if_the_hospital_number_has_already_been_merged(self, load_patient):
         """
         The MRN has already been merged, raise a Value Error


### PR DESCRIPTION
Includes the MRN in the error log statement so that we can then more easily find out what is causing the issue.

Adds an additional unit test.