### PR TITLE
strip leading zeros in demographics.update_from_dict

### DIFF
--- a/elcid/models.py
+++ b/elcid/models.py
@@ -73,12 +73,12 @@ class Demographics(PreviousMRN, omodels.Demographics, ExternallySourcedModel):
         if self.date_of_birth:
             return datetime.date.today().year - self.date_of_birth.year
 
-    def set_hospital_number(self, value, user, *args, **kwargs):
+    def save(self, *args, **kwargs):
         """
         Remove any zero prefix on the hospital number
         """
-        value = value.lstrip('0')
-        self.hospital_number = value
+        self.hospital_number = self.hospital_number.lstrip('0')
+        super().save(*args, **kwargs)
 
     class Meta:
         verbose_name_plural = "Demographics"

--- a/elcid/models.py
+++ b/elcid/models.py
@@ -42,11 +42,11 @@ class MergedMRN(models.Model):
 
 class PreviousMRN(models.Model):
     """
-    A mixin for subrecords to maintain an audit trail for occasions 
+    A mixin for subrecords to maintain an audit trail for occasions
     when an upstream MRN merge occurs and the merged MRN has elCID entries.
-    
+
     `previous_mrn` is the MRN in use at the time that this subrecord instance
-    was last created/edited with if that MRN is different from the current 
+    was last created/edited with if that MRN is different from the current
     value of `Demographics.hospital_number` attached to this instance.
     """
     previous_mrn = models.CharField(blank=True, null=True, max_length=256)
@@ -72,6 +72,13 @@ class Demographics(PreviousMRN, omodels.Demographics, ExternallySourcedModel):
     def age(self):
         if self.date_of_birth:
             return datetime.date.today().year - self.date_of_birth.year
+
+    def set_hospital_number(self, value, user, *args, **kwargs):
+        """
+        Remove any zero prefix on the hospital number
+        """
+        value = value.lstrip('0')
+        self.hospital_number = value
 
     class Meta:
         verbose_name_plural = "Demographics"

--- a/elcid/test/test_models.py
+++ b/elcid/test/test_models.py
@@ -90,16 +90,6 @@ class DemographicsTest(OpalTestCase, AbstractPatientTestCase):
         self.assertEqual(datetime.date(1972, 6, 21), demographics.date_of_birth)
         self.assertEqual('AA1112', demographics.hospital_number)
 
-    def test_update_from_dict_zero_prefix(self):
-        data = {
-            'consistency_token': '12345678',
-            'id': self.demographics.id,
-            'hospital_number': '0AA1112',
-            }
-        self.demographics.update_from_dict(data, self.user)
-        demographics = self.patient.demographics_set.get()
-        self.assertEqual('AA1112', demographics.hospital_number)
-
     def test_update_from_dict_with_missing_consistency_token(self):
         with self.assertRaises(exceptions.MissingConsistencyTokenError):
             self.demographics.update_from_dict({}, self.user)
@@ -109,6 +99,12 @@ class DemographicsTest(OpalTestCase, AbstractPatientTestCase):
             self.demographics.update_from_dict(
                 {'consistency_token': '87654321'}, self.user
             )
+
+    def test_save(self):
+        self.demographics.hospital_number = '0AA1112'
+        self.demographics.save()
+        self.demographics.refresh_from_db()
+        self.assertEqual('AA1112', self.demographics.hospital_number)
 
 
 class LocationTest(OpalTestCase, AbstractEpisodeTestCase):

--- a/elcid/test/test_models.py
+++ b/elcid/test/test_models.py
@@ -90,6 +90,16 @@ class DemographicsTest(OpalTestCase, AbstractPatientTestCase):
         self.assertEqual(datetime.date(1972, 6, 21), demographics.date_of_birth)
         self.assertEqual('AA1112', demographics.hospital_number)
 
+    def test_update_from_dict_zero_prefix(self):
+        data = {
+            'consistency_token': '12345678',
+            'id': self.demographics.id,
+            'hospital_number': '0AA1112',
+            }
+        self.demographics.update_from_dict(data, self.user)
+        demographics = self.patient.demographics_set.get()
+        self.assertEqual('AA1112', demographics.hospital_number)
+
     def test_update_from_dict_with_missing_consistency_token(self):
         with self.assertRaises(exceptions.MissingConsistencyTokenError):
             self.demographics.update_from_dict({}, self.user)


### PR DESCRIPTION
This strips leading zeros in the update from dict method. 

This is not the cleanest as if they save the form then the UI will show leading zeros in the MRN until they update the page however given that this edge case should only possibly happen in 0.4% of all patients I think this is quirk is ok rather than the code overhead of doing it in a directive or some such.