### PR TITLE
Use get_or_create_patient in the IPC status table

### DIFF
--- a/plugins/ipc/management/commands/load_ipc_status.py
+++ b/plugins/ipc/management/commands/load_ipc_status.py
@@ -100,7 +100,10 @@ class Command(BaseCommand):
                 if len(mrn) == 0:
                     continue
                 else:
-                    patient = loader.create_rfh_patient_from_hospital_number(
+                    # The table contains multiple results for the same
+                    # MRN so get or create in case they have already
+                    # recently been created.
+                    patient, _ = loader.get_or_create_patient(
                         mrn, elcid_episode_categories.InfectionService
                     )
 

--- a/plugins/ipc/tests/test_load_ipc_status.py
+++ b/plugins/ipc/tests/test_load_ipc_status.py
@@ -35,8 +35,8 @@ class LoadIPCTestCase(OpalTestCase):
         self.assertEqual(ipc_status.comments, "A comment")
 
     @patch('plugins.ipc.management.commands.load_ipc_status.ProdAPI')
-    @patch('intrahospital_api.loader.create_rfh_patient_from_hospital_number')
-    def test_creates_patient(self, create_rfh_patient_from_hospital_number, ProdAPI):
+    @patch('intrahospital_api.loader.get_or_create_patient')
+    def test_creates_patient(self, get_or_create_patient, ProdAPI):
         ProdAPI.return_value.execute_hospital_query.return_value = [self.upstream_row]
         self.upstream_row["Patient_Number"] = "234"
         def create_patient():
@@ -46,7 +46,7 @@ class LoadIPCTestCase(OpalTestCase):
             episode.save()
             return patient
 
-        create_rfh_patient_from_hospital_number.side_effect = lambda x, y: create_patient()
+        get_or_create_patient.side_effect = lambda x, y: (create_patient(), True,)
         self.cmd.handle()
         self.assertTrue(
             Patient.objects.filter(


### PR DESCRIPTION
The IPC Status tables has multiple rows per MRN, make sure we don't error when loading these in.