### PR TITLE
Merge patient covid loader

### DIFF
--- a/plugins/covid/tests/test_loader.py
+++ b/plugins/covid/tests/test_loader.py
@@ -6,6 +6,62 @@ from plugins.covid import episode_categories
 from elcid.episode_categories import InfectionService
 
 
+@mock.patch("plugins.covid.loader.create_rfh_patient_from_hospital_number")
+@mock.patch("plugins.covid.loader.ProdAPI")
+class PreLoadCovidPatientTestCase(OpalTestCase):
+    def test_create_patient_who_does_not_exist(
+        self,
+        ProdAPI,
+        create_rfh_patient_from_hospital_number
+    ):
+        ProdAPI.return_value.execute_trust_query.return_value = [
+            {"Patient_Number": "111"}
+        ]
+        loader.pre_load_covid_patients()
+        create_rfh_patient_from_hospital_number.assert_called_once_with(
+            "111", InfectionService
+        )
+
+    def test_doesnt_create_patient_who_exists(
+        self,
+        ProdAPI,
+        create_rfh_patient_from_hospital_number
+    ):
+        patient, _ = self.new_patient_and_episode_please()
+        patient.demographics_set.update(
+            hospital_number="111"
+        )
+        ProdAPI.return_value.execute_trust_query.return_value = [
+            {"Patient_Number": "111"}
+        ]
+        loader.pre_load_covid_patients()
+        self.assertFalse(create_rfh_patient_from_hospital_number.called)
+
+    def test_create_patients_with_zeroes_stripped(
+        self,
+        ProdAPI,
+        create_rfh_patient_from_hospital_number
+    ):
+        ProdAPI.return_value.execute_trust_query.return_value = [
+            {"Patient_Number": "0111"}
+        ]
+        loader.pre_load_covid_patients()
+        create_rfh_patient_from_hospital_number.assert_called_once_with(
+            "111", InfectionService
+        )
+
+    def test_doesnt_create_patient_with_only_zeros(
+        self,
+        ProdAPI,
+        create_rfh_patient_from_hospital_number
+    ):
+        ProdAPI.return_value.execute_trust_query.return_value = [
+            {"Patient_Number": "0"}
+        ]
+        loader.pre_load_covid_patients()
+        self.assertFalse(create_rfh_patient_from_hospital_number.called)
+
+
 
 @mock.patch("plugins.covid.loader.create_rfh_patient_from_hospital_number")
 @mock.patch("plugins.covid.loader.ProdAPI")


### PR DESCRIPTION
Changes the COVID loader to deal with merged MRNs.

I did remove the existing_hospital_numbers logic as this is done in the get_or_create. It felt like a necessary speed improvement during the pandemic that could now be removed for simpler code.