### PR TITLE
Fixes the bed status loader so bed status.patient can be None

### DIFF
--- a/plugins/admissions/loader.py
+++ b/plugins/admissions/loader.py
@@ -320,17 +320,10 @@ def load_bed_status():
                 )
 
     with transaction.atomic():
-
         BedStatus.objects.all().delete()
-
         for bed_data in status:
+            # A bed can not have a patient, this is ok.
             patient = mrn_to_patient.get(bed_data["Local_Patient_Identifier"])
-            # find_patients_from_mrns excludes invalid MRNs,
-            # if the patient identifier is not present it means
-            # it is either Nones, an empty string, only made up of zeros or empty spaces
-            # in this case, skip it.
-            if not patient:
-                continue
             bed_status = BedStatus(patient=patient)
             for k, v in bed_data.items():
                 setattr(

--- a/plugins/admissions/tests/test_loader.py
+++ b/plugins/admissions/tests/test_loader.py
@@ -97,3 +97,12 @@ class LoadBedStatusTestCase(OpalTestCase):
         self.assertEqual(
             bed_status.patient, patient
         )
+
+    def test_bed_status_can_have_none_patient(self, prod_api, create_rfh_patient_from_hospital_number):
+        self.bed_status_row["Local_Patient_Identifier"] = None
+        prod_api.return_value.execute_warehouse_query.return_value =[
+            self.bed_status_row
+        ]
+        loader.load_bed_status()
+        bed_status = models.BedStatus.objects.get()
+        self.assertIsNone(bed_status.patient)


### PR DESCRIPTION
BedStatus is a list of locations, we expect patient to be None frequently.

This has always been the live behaviour but was changed on the Cerner Merge Branch. This fixes that.