### PR TITLE
Fixes a bug where get_or_create_patient with rfh_patient = False errored

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -76,6 +76,8 @@ def create_rfh_patient_from_hospital_number(
         active_mrn, merged_mrn_dicts = update_demographics.get_active_mrn_and_merged_mrn_data(
             hospital_number
         )
+    else:
+        active_mrn = hospital_number
 
     patient = Patient.objects.create()
     patient.demographics_set.update(


### PR DESCRIPTION
intrahospital_api.loader.get_or_create_patient should not error when rfh_patient is False but should handle it.

Also adds a couple of unit tests to make sure the rfh and non rfh cases are covered.