### PR TITLE
New patient demographics search with merged mrn

### DIFF
--- a/elcid/api.py
+++ b/elcid/api.py
@@ -584,7 +584,7 @@ class DemographicsSearch(LoginRequiredViewset):
             return json_response(dict(status=self.PATIENT_NOT_FOUND))
         else:
             if settings.USE_UPSTREAM_DEMOGRAPHICS:
-                demographics = loader.load_demographics(hospital_number)
+                demographics = loader.search_upstream_demographics(hospital_number)
                 if demographics:
                     return json_response(dict(
                         patient=dict(demographics=[demographics]),

--- a/elcid/api.py
+++ b/elcid/api.py
@@ -573,6 +573,17 @@ class DemographicsSearch(LoginRequiredViewset):
             hospital_number=hospital_number
         ).last()
 
+        # If we can't find a patient in demographics
+        # check to see if it is an inactive MRN that
+        # has been merged with a different MRN on elcid
+        if not demographics:
+            merged_mrn = emodels.MergedMRN.objects.filter(
+                mrn=hospital_number
+            ).first()
+            if merged_mrn:
+                demographics = merged_mrn.patient.demographics()
+
+
         # the patient is in elcid
         if demographics:
             return json_response(dict(

--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -1,11 +1,8 @@
 """
 Pathways for the RFH elCID application
 """
-import datetime
-
 from django.db import transaction
 from django.http import HttpResponseBadRequest
-from django.conf import settings
 from opal.core.pathway.pathways import (
     Step,
     PagePathway,

--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -100,21 +100,7 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
 
         Else if the patient doesn't exist load in the patient.
         """
-
-        hospital = ""
-        if "location" in data:
-            hospital = data['location'][0].get('hospital', "")
-
         if patient:
-            if hospital == 'RNOH':
-                rnoh_episode = patient.episode_set.filter(
-                    category_name=RNOHEpisode.display_name
-                ).last()
-                if rnoh_episode:
-                    return super(AddPatientPathway, self).save(
-                        data, user=user, patient=patient, episode=rnoh_episode
-                    )
-
             infectious_episode = patient.episode_set.filter(
                 category_name=InfectionService.display_name
             ).last()
@@ -139,11 +125,4 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
             saved_patient, saved_episode = super(AddPatientPathway, self).save(
                 data, user=user, patient=patient, episode=episode
             )
-
-        if hospital == 'RNOH':
-            # Move the location data to an RNOH episode,
-            # create a background infection episode
-            saved_episode.category_name = RNOHEpisode.display_name
-            saved_episode.save()
-            saved_patient.create_episode(category_name=InfectionService.display_name)
         return saved_patient, saved_episode

--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -146,7 +146,7 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
         # if the patient its a new patient and we have
         # got their demographics from the upstream api service
         # bring in their lab tests
-        if not patient and settings.ADD_PATIENT_LAB_TESTS:
+        if not patient:
             demo_system = data["demographics"][0].get("external_system")
             if demo_system == constants.EXTERNAL_SYSTEM:
                 loader.load_patient(saved_patient)

--- a/elcid/pathways.py
+++ b/elcid/pathways.py
@@ -150,5 +150,4 @@ class AddPatientPathway(SaveTaggingMixin, WizardPathway):
             demo_system = data["demographics"][0].get("external_system")
             if demo_system == constants.EXTERNAL_SYSTEM:
                 loader.load_patient(saved_patient)
-
         return saved_patient, saved_episode

--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -246,8 +246,6 @@ EPMA_DB = dict(
 # search with external demographics when adding a patient
 ADD_PATIENT_DEMOGRAPHICS = True
 
-# after we've added a patient, should we load in the labtests?
-ADD_PATIENT_LAB_TESTS = True
 
 #### END API Settings
 

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -433,11 +433,11 @@ class DemographicsSearchTestCase(OpalTestCase):
         self.assertEqual(self.client.get(self.raw_url).status_code, 400)
 
     @override_settings(USE_UPSTREAM_DEMOGRAPHICS=True)
-    @mock.patch("elcid.api.loader.load_demographics")
+    @mock.patch("elcid.api.loader.search_upstream_demographics")
     def test_with_demographics_add_patient_not_found(
-        self, load_demographics
+        self, search_upstream_demographics
     ):
-        load_demographics.return_value = None
+        search_upstream_demographics.return_value = None
         response = json.loads(
             self.client.get(self.url).content.decode('utf-8')
         )
@@ -446,11 +446,11 @@ class DemographicsSearchTestCase(OpalTestCase):
         )
 
     @override_settings(USE_UPSTREAM_DEMOGRAPHICS=True)
-    @mock.patch("elcid.api.loader.load_demographics")
+    @mock.patch("elcid.api.loader.search_upstream_demographics")
     def test_with_demographics_add_patient_found_upstream(
-        self, load_demographics
+        self, search_upstream_demographics
     ):
-        load_demographics.return_value = dict(first_name="Wilma")
+        search_upstream_demographics.return_value = dict(first_name="Wilma")
         response = json.loads(
             self.client.get(self.get_url('01')).content.decode('utf-8')
         )
@@ -460,18 +460,18 @@ class DemographicsSearchTestCase(OpalTestCase):
         self.assertEqual(
             response["patient"]["demographics"][0]["first_name"], "Wilma"
         )
-        load_demographics.assert_called_once_with('1')
+        search_upstream_demographics.assert_called_once_with('1')
 
     @override_settings(USE_UPSTREAM_DEMOGRAPHICS=True)
-    @mock.patch("elcid.api.loader.load_demographics")
+    @mock.patch("elcid.api.loader.search_upstream_demographics")
     def test_with_demographics_add_patient_found_upstream_without_zeros(
-        self, load_demographics
+        self, search_upstream_demographics
     ):
         """
         When we query upstream demographics, query should use
         the hn without preceding zeros.
         """
-        load_demographics.return_value = dict(first_name="Wilma")
+        search_upstream_demographics.return_value = dict(first_name="Wilma")
         response = json.loads(
             self.client.get(self.get_url('01')).content.decode('utf-8')
         )
@@ -481,7 +481,7 @@ class DemographicsSearchTestCase(OpalTestCase):
         self.assertEqual(
             response["patient"]["demographics"][0]["first_name"], "Wilma"
         )
-        load_demographics.assert_called_once_with('1')
+        search_upstream_demographics.assert_called_once_with('1')
 
     def test_patient_found(self):
         self.get_patient("Wilma", "1")

--- a/elcid/test/test_api.py
+++ b/elcid/test/test_api.py
@@ -493,6 +493,20 @@ class DemographicsSearchTestCase(OpalTestCase):
             response["patient"]["demographics"][0]["first_name"], "Wilma"
         )
 
+    def test_patient_found_with_merged_mrn(self):
+        patient = self.get_patient("Wilma", "123")
+        patient.mergedmrn_set.create(
+            mrn="1", our_merge_datetime=timezone.now()
+        )
+        response = json.loads(self.client.get(self.url).content.decode('utf-8'))
+        self.assertEqual(
+            response["status"], "patient_found_in_elcid"
+        )
+        self.assertEqual(
+            response["patient"]["demographics"][0]["first_name"], "Wilma"
+        )
+
+
     def test_with_demographics_add_patient_in_elcid_without_zeros(self):
         """
         When we querying within elcid, query should use

--- a/elcid/test/test_pathways.py
+++ b/elcid/test/test_pathways.py
@@ -176,20 +176,3 @@ class TestAddPatientPathway(OpalTestCase):
         self.assertTrue(
             emodels.Demographics.objects.filter(hospital_number="234").exists()
         )
-
-    def test_creates_rnoh_episodes(self, create_rfh_patient_from_hospital_number):
-        """
-        We should create RNOH episodes if the hospital is RNOH
-        """
-        create_rfh_patient_from_hospital_number.side_effect = update_demographics.CernerPatientNotFoundException(
-            "Not found upstream because they are from RNOH"
-        )
-        url = AddPatientPathway().save_url()
-        test_data = dict(
-            demographics=[dict(hospital_number="00234", nhs_number="12312")],
-            location=[dict(ward="9W", hospital="RNOH")]
-        )
-        self.post_json(url, test_data)
-        self.assertTrue(
-            emodels.Demographics.objects.filter(hospital_number="234").exists()
-        )

--- a/elcid/test/test_pathways.py
+++ b/elcid/test/test_pathways.py
@@ -100,7 +100,6 @@ class TestAddPatientPathway(OpalTestCase):
         self.url = AddPatientPathway().save_url()
 
     @patch("elcid.pathways.loader.load_patient")
-    @override_settings(ADD_PATIENT_LAB_TESTS=True)
     def test_queries_loader_if_external_demographics(self, load_patient):
         test_data = dict(
             demographics=[dict(
@@ -117,7 +116,6 @@ class TestAddPatientPathway(OpalTestCase):
         )
 
     @patch("elcid.pathways.loader.load_patient")
-    @override_settings(ADD_PATIENT_LAB_TESTS=True)
     def test_does_not_query_loader_if_local_demographics(
         self, load_patient
     ):

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -34,7 +34,10 @@ def log_errors(name):
 def search_upstream_demographics(hospital_number):
     started = timezone.now()
     try:
-        result = api.demographics(hospital_number)
+        active_mrn, _ = update_demographics.get_active_mrn_and_merged_mrn_data(
+            hospital_number
+        )
+        result = api.demographics(active_mrn)
     except:
         stopped = timezone.now()
         logger.info("searching upstream demographics failed in {}".format(
@@ -136,6 +139,7 @@ def async_load_patient(patient_id, patient_load_id):
     except:
         log_errors("_load_patient")
         raise
+
 
 @timing
 def _load_patient(patient, patient_load):

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -31,16 +31,16 @@ def log_errors(name):
 
 
 @timing
-def load_demographics(hospital_number):
+def search_upstream_demographics(hospital_number):
     started = timezone.now()
     try:
         result = api.demographics(hospital_number)
     except:
         stopped = timezone.now()
-        logger.info("demographics load failed in {}".format(
+        logger.info("searching upstream demographics failed in {}".format(
             (stopped - started).seconds
         ))
-        log_errors("load_demographics")
+        log_errors("search_upstream_demographics")
         return
 
     return result

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -197,10 +197,10 @@ def get_or_create_patient(
     episode category.
 
     If the patient is in the upstream Cerner master file, create the patient and
-    load in the upstream datadata.
+    load in the upstream data.
 
-    If the patient is not found in the cerner master file, just create an elCID
-    patient with no data.
+    If the patient is not found in the Cerner master file, create an elCID
+    patient and do not attempt to query upstream data sources.
 
     If run_async is False the loaders that look for upstream data
     will be called synchronously.

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -226,7 +226,7 @@ def get_or_create_patient(
         )
     except update_demographics.CernerPatientNotFoundException:
         logger.info(
-            f"Unable to find MRN {mrn} in cerner, creating the patient without the upstream data"
+            f"Unable to find MRN {mrn} in Cerner, creating the patient without the upstream data"
         )
         patient = Patient.objects.create()
         patient.demographics_set.update(

--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -196,7 +196,7 @@ def get_or_create_patient(
     Get or create a opal.Patient with an opal.Episode of the
     episode category.
 
-    If the patient is in the upstream cerner master file, create the patient and
+    If the patient is in the upstream Cerner master file, create the patient and
     load in the upstream datadata.
 
     If the patient is not found in the cerner master file, just create an elCID

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -112,7 +112,7 @@ class LoadDemographicsTestCase(ApiTestCase):
     @mock.patch.object(loader.api, 'demographics')
     def test_success(self, demographics):
         demographics.return_value = "success"
-        result = loader.load_demographics("some_hospital_number")
+        result = loader.search_upstream_demographics("some_hospital_number")
         demographics.assert_called_once_with("some_hospital_number")
         self.assertEqual(result, "success")
 
@@ -122,15 +122,15 @@ class LoadDemographicsTestCase(ApiTestCase):
     def test_failed(self, log_err, info, demographics):
         demographics.side_effect = ValueError("Boom")
         demographics.return_value = "success"
-        loader.load_demographics("some_hospital_number")
+        loader.search_upstream_demographics("some_hospital_number")
         self.assertEqual(info.call_count, 1)
-        log_err.assert_called_once_with("load_demographics")
+        log_err.assert_called_once_with("search_upstream_demographics")
 
     @override_settings(
         INTRAHOSPITAL_API='intrahospital_api.apis.dev_api.DevApi'
     )
     def test_integration(self):
-        result = loader.load_demographics("some_number")
+        result = loader.search_upstream_demographics("some_number")
         self.assertTrue(isinstance(result, dict))
 
 


### PR DESCRIPTION
* Renames load_demographics to search_upstream_demographics as this is what it actually is
* Changes search_upstream_demographics so that it checks to see if the mrn has been merged and then returns results if it has
* Changes the add patient search view to check to see if we have a local merged mrn before returning a result
* Changes the add patient step to use get_or_create_rfh_patient if they exist upstream
* Changes the AddAntifungalPatients to create MergedMRNs