### PR TITLE
Changes update_demographics merge messages to be warn not error

### DIFF
--- a/intrahospital_api/test/test_update_demographics.py
+++ b/intrahospital_api/test/test_update_demographics.py
@@ -652,7 +652,7 @@ class GetActiveMrnAndMergedMrnDataTestCase(OpalTestCase):
         )
         self.assertEqual(active_mrn, "123")
         self.assertEqual(merged_data, [])
-        logger.error.assert_called_once_with(
+        logger.warn.assert_called_once_with(
             "Unable to find an active MRN for 123"
         )
 
@@ -672,7 +672,7 @@ class GetActiveMrnAndMergedMrnDataTestCase(OpalTestCase):
         )
         self.assertEqual(active_mrn, "123")
         self.assertEqual(merged_data, [])
-        logger.error.assert_called_once_with(
+        logger.warn.assert_called_once_with(
             "Merge exception raised for 123 with 'Multiple active related MRNs (123, 234) found for 123'"
         )
 

--- a/intrahospital_api/update_demographics.py
+++ b/intrahospital_api/update_demographics.py
@@ -325,22 +325,21 @@ def get_active_mrn_and_merged_mrn_data(mrn):
         # The patient is not merged
         return mrn, []
     if not row["MERGE_COMMENTS"]:
-        logger.error(
+        logger.warn(
             f"MRN {mrn} is marked as merged but there is not merge comment"
         )
 
     try:
         active_mrn, merged_mrn_dicts = parse_merge_comments(mrn)
     except MergeException as err:
-        logger.error(f"Merge exception raised for {mrn} with '{err}'")
+        logger.warn(f"Merge exception raised for {mrn} with '{err}'")
         return mrn, []
 
     if not active_mrn:
-        logger.error(f"Unable to find an active MRN for {mrn}")
+        logger.warn(f"Unable to find an active MRN for {mrn}")
         return mrn, []
 
     return active_mrn, merged_mrn_dicts
-
 
 def update_patient_subrecords_from_upstream_dict(patient, upstream_patient_information):
     """


### PR DESCRIPTION
We have a significant amount of upstream rows that involve flawed merges. If we error message on each of these we get a significant amount of emails. This is not an effective way of managing these issues.

At the last run there were ~70 of these issues. 
4 of them are patients that are marked as merged where there are multiple active MRNs. 
The rest are patients that are marked as merged but have no merge comment, I checked a few of these and they were active

