### PR TITLE
If a patient id is passed to a celery task that does not exist, do not error

### DIFF
--- a/intrahospital_api/loader.py
+++ b/intrahospital_api/loader.py
@@ -129,7 +129,11 @@ def async_task(patient, patient_load):
 
 
 def async_load_patient(patient_id, patient_load_id):
-    patient = Patient.objects.get(id=patient_id)
+    patient = Patient.objects.filter(id=patient_id).first()
+    # If the patient does not exist then we assume they have been merged
+    # and then deleted.
+    if not patient:
+        return
     patient_load = models.InitialPatientLoad.objects.get(id=patient_load_id)
     try:
         _load_patient(patient, patient_load)

--- a/intrahospital_api/test/test_loader.py
+++ b/intrahospital_api/test/test_loader.py
@@ -245,6 +245,12 @@ class AsyncLoadPatientTestCase(ApiTestCase):
         log_errors.assert_called_once_with("_load_patient")
         self.assertEqual(str(ve.exception), "Boom")
 
+    def test_no_patient(self, load_patient, log_errors):
+        result = loader.async_load_patient(self.patient.id+1, self.patient_load.id+1)
+        self.assertIsNone(result)
+        self.assertFalse(load_patient.called)
+        self.assertFalse(log_errors.called)
+
 
 class UpdatePatientFromBatchTestCase(ApiTestCase):
     def setUp(self, *args, **kwargs):


### PR DESCRIPTION
A patient can be deleted, most probably by merge_patient so handle the fact a patient does not exist gracefully.