### PR TITLE
Changes create_tb_observations to always run for all time

### DIFF
--- a/plugins/tb/management/commands/create_tb_observations.py
+++ b/plugins/tb/management/commands/create_tb_observations.py
@@ -17,8 +17,8 @@ TB_OBSERVATIONS = [models.TBPCR, models.AFBSmear, models.AFBCulture, models.AFBR
 
 
 @transaction.atomic
-def populate_tests(since):
-    labtests_obs_qs = Observation.objects.filter(last_updated__gte=since)
+def populate_tests():
+    labtests_obs_qs = Observation.objects.all()
 
     for tb_obs_model in TB_OBSERVATIONS:
         labtests_tb_obs_qs = labtests_obs_qs.filter(
@@ -47,9 +47,8 @@ def populate_tests(since):
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        three_days_ago = timezone.now() - datetime.timedelta(3)
         start = time.time()
-        populate_tests(three_days_ago)
+        populate_tests()
         end_populate = time.time()
         logger.info(
             f"Creating TB observations: Finished creating TB tests in {end_populate-start}s"

--- a/plugins/tb/tests/test_create_tb_observations.py
+++ b/plugins/tb/tests/test_create_tb_observations.py
@@ -1,0 +1,129 @@
+from django.utils import timezone
+import datetime
+from opal.core.test import OpalTestCase
+from plugins.tb.management.commands import create_tb_observations
+from plugins.tb import models as tb_models
+from plugins.tb import episode_categories
+
+class PopulateTestsTestCase(OpalTestCase):
+	def setUp(self):
+		self.patient, _ = self.new_patient_and_episode_please()
+		self.now = timezone.now()
+		self.yesterday = self.now - datetime.timedelta(1)
+
+	def test_creates_afb_smear(self):
+		lt = self.patient.lab_tests.create(
+			test_name='AFB : CULTURE',
+			lab_number="123",
+			site="chest",
+		)
+		lt.observation_set.create(
+			observation_datetime=self.yesterday,
+			reported_datetime=self.now,
+			observation_value='AAFB + Seen.',
+			observation_name='AFB Smear'
+		)
+		create_tb_observations.populate_tests()
+		afb_smear = tb_models.AFBSmear.objects.get()
+		self.assertTrue(afb_smear.positive)
+
+
+	def test_creates_afb_culture(self):
+		lt = self.patient.lab_tests.create(
+			test_name='AFB : CULTURE',
+			lab_number="123",
+			site="chest",
+		)
+		lt.observation_set.create(
+			observation_datetime=self.yesterday,
+			reported_datetime=self.now,
+			observation_value='1) Mycobacterium sp.~  Isolate sent to Reference Laboratory~~~',
+			observation_name='TB: Culture Result'
+		)
+		create_tb_observations.populate_tests()
+		afb_culture = tb_models.AFBCulture.objects.get()
+		self.assertTrue(afb_culture.positive)
+
+
+	def test_creates_afb_ref_lab(self):
+		lt = self.patient.lab_tests.create(
+			test_name='AFB : CULTURE',
+			lab_number="123",
+			site="chest",
+		)
+		lt.observation_set.create(
+			observation_datetime=self.yesterday,
+			reported_datetime=self.now,
+			observation_value="1) Mycobacterium tuberculosis~  This is a final reference laboratory report~~                        1)~  Ethambutol            S~  Isoniazid             S~  Pyrazinamide          S~  Rifampicin            S~~",
+			observation_name='TB Ref. Lab. Culture result'
+		)
+		create_tb_observations.populate_tests()
+		afb_ref_lab = tb_models.AFBRefLab.objects.get()
+		self.assertTrue(afb_ref_lab.positive)
+
+	def test_creates_pcr(self):
+		lt = self.patient.lab_tests.create(
+			test_name='TB PCR TEST',
+			lab_number="123",
+			site="chest",
+		)
+		lt.observation_set.create(
+			observation_datetime=self.yesterday,
+			reported_datetime=self.now,
+			observation_value="The PCR to detect M.tuberculosis complex was~POSITIVE",
+			observation_name='TB PCR'
+		)
+		create_tb_observations.populate_tests()
+		tb_pcr = tb_models.TBPCR.objects.get()
+		self.assertTrue(tb_pcr.positive)
+
+class CMDTestCase(OpalTestCase):
+	def setUp(self):
+		self.patient, _ = self.new_patient_and_episode_please()
+		self.cmd = create_tb_observations.Command()
+
+	def create_positive_tb_test(self):
+		now = timezone.now()
+		yesterday = now - datetime.timedelta(1)
+
+		lt = self.patient.lab_tests.create(
+			test_name='TB PCR TEST',
+			lab_number="123",
+			site="chest",
+		)
+		lt.observation_set.create(
+			observation_datetime=yesterday,
+			reported_datetime=now,
+			observation_value="The PCR to detect M.tuberculosis complex was~POSITIVE",
+			observation_name='TB PCR'
+		)
+
+	def test_creates_tb_episodes_if_needed(self):
+		self.create_positive_tb_test()
+		self.cmd.handle()
+		self.assertTrue(
+			self.patient.episode_set.filter(
+				category_name=episode_categories.TbEpisode.display_name
+			).exists()
+		)
+
+	def test_does_not_create_tb_episode_if_one_already_exists(self):
+		self.create_positive_tb_test()
+		self.patient.episode_set.create(
+			category_name=episode_categories.TbEpisode.display_name
+		)
+		self.cmd.handle()
+		self.assertEqual(
+			self.patient.episode_set.filter(
+				category_name=episode_categories.TbEpisode.display_name
+			).count(),
+			1
+		)
+
+	def test_does_not_create_tb_episode_if_not_needed(self):
+		self.cmd.handle()
+		self.assertFalse(
+			self.patient.episode_set.filter(
+				category_name=episode_categories.TbEpisode.display_name
+			).exists()
+		)


### PR DESCRIPTION
At the moment there is a bug if a patient is created who has TB tests prior to 3 days ago, they are not added to the MDT list. We may as well run for all time..

Some timings...
It takes 4 mins as is, 11 mins to run for 8 days and 15 mins to run for all time with the current test server load.

So I think we may as well just run for all time, thoughts?