### PR TITLE
Adds in a merge_dup_episode_categories mgmt command

### DIFF
--- a/intrahospital_api/management/commands/merge_dup_episode_categories.py
+++ b/intrahospital_api/management/commands/merge_dup_episode_categories.py
@@ -80,20 +80,13 @@ def move_non_singletons(subrecord_cls, old_parent, new_parent):
             old_subrecord.save()
 
 
-def move_record(subrecord_cls, old_parent, new_parent):
-    if getattr(subrecord_cls, "_is_singleton", False):
-        update_singleton(subrecord_cls, old_parent, new_parent)
-    else:
-        move_non_singletons(subrecord_cls, old_parent, new_parent)
-
-
 def merge_episode(*, old_episode, new_episode):
     for episode_related_model in merge_patient.EPISODE_RELATED_MODELS:
-        move_record(
-            episode_related_model,
-            old_episode,
-            new_episode,
-        )
+        if getattr(episode_related_model, "_is_singleton", False):
+            update_singleton(episode_related_model, old_episode, new_episode)
+        else:
+            move_non_singletons(episode_related_model, old_episode, new_episode)
+
 
 @transaction.atomic
 def merge_patient_episodes(patient_id):

--- a/intrahospital_api/management/commands/merge_dup_episode_categories.py
+++ b/intrahospital_api/management/commands/merge_dup_episode_categories.py
@@ -13,9 +13,9 @@ from elcid.utils import timing
 DELETE_FILE = "deleted_episodes.txt"
 
 
-def update_singleton(subrecord_cls, old_parent, new_parent):
-    old_singleton = subrecord_cls.objects.get(episode=old_parent)
-    new_singleton = subrecord_cls.objects.get(episode=new_parent)
+def update_singleton(subrecord_cls, old_episode, new_episode):
+    old_singleton = subrecord_cls.objects.get(episode=old_episode)
+    new_singleton = subrecord_cls.objects.get(episode=new_episode)
 
     if not old_singleton.updated:
         # the old singleton was never editted, we can skip
@@ -24,7 +24,7 @@ def update_singleton(subrecord_cls, old_parent, new_parent):
         # the new singleton was never editted, we can delete
         # it and replace it with the old one.
         new_singleton.delete()
-        old_singleton.episode = new_parent
+        old_singleton.episode = new_episode
         with reversion.create_revision():
             old_singleton.save()
     else:
@@ -58,24 +58,23 @@ def update_singleton(subrecord_cls, old_parent, new_parent):
                 new_singleton.save()
 
 
-def move_non_singletons(subrecord_cls, old_parent, new_parent):
+def move_non_singletons(subrecord_cls, old_episode, new_episode):
     """
-    Moves the old_subrecords query set onto the new parent (a patient or episode).
-    In doing so it updates the previous_mrn field to be that of the old_mrn
+    Updates the old_subrecords query set to the new episode.
     """
-    if new_parent.__class__ == opal_models.Episode:
+    if new_episode.__class__ == opal_models.Episode:
         is_episode_subrecord = True
     else:
         is_episode_subrecord = False
     if is_episode_subrecord:
-        old_subrecords = subrecord_cls.objects.filter(episode=old_parent)
+        old_subrecords = subrecord_cls.objects.filter(episode=old_episode)
     else:
-        old_subrecords = subrecord_cls.objects.filter(patient=old_parent)
+        old_subrecords = subrecord_cls.objects.filter(patient=old_episode)
     for old_subrecord in old_subrecords:
         if is_episode_subrecord:
-            old_subrecord.episode = new_parent
+            old_subrecord.episode = new_episode
         else:
-            old_subrecord.patient = new_parent
+            old_subrecord.patient = new_episode
         with reversion.create_revision():
             old_subrecord.save()
 

--- a/intrahospital_api/management/commands/merge_dup_episode_categories.py
+++ b/intrahospital_api/management/commands/merge_dup_episode_categories.py
@@ -1,0 +1,131 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from intrahospital_api.apis.prod_api import ProdApi as ProdAPI
+from intrahospital_api import logger, merge_patient
+from elcid.utils import timing
+from intrahospital_api import merge_patient
+from opal import models as opal_models
+from django.db import transaction
+from django.db.models import Count
+import reversion
+from elcid.utils import timing
+
+DELETE_FILE = "deleted_episodes.txt"
+
+
+def update_singleton(subrecord_cls, old_parent, new_parent):
+    old_singleton = subrecord_cls.objects.get(episode=old_parent)
+    new_singleton = subrecord_cls.objects.get(episode=new_parent)
+
+    if not old_singleton.updated:
+        # the old singleton was never editted, we can skip
+        return
+    if not new_singleton.updated:
+        # the new singleton was never editted, we can delete
+        # it and replace it with the old one.
+        new_singleton.delete()
+        old_singleton.episode = new_parent
+        with reversion.create_revision():
+            old_singleton.save()
+    else:
+        if new_singleton.updated < old_singleton.updated:
+            # the old singleton is new than the new singleton
+            # stamp the new singleton as reversion
+            # then copy over all the fields from the old
+            # onto the new
+            for field in old_singleton._meta.get_fields():
+                field_name = field.name
+                if field_name in merge_patient.IGNORED_FIELDS:
+                    continue
+                setattr(new_singleton, field_name, getattr(old_singleton, field_name))
+            with reversion.create_revision():
+                new_singleton.save()
+        else:
+            # the old singleton is older than the new singleton
+            # create a reversion record with the data of the old
+            # singleton, then continue with the more recent data
+            more_recent_data = {}
+            for field in new_singleton._meta.get_fields():
+                field_name = field.name
+                if field_name in merge_patient.IGNORED_FIELDS:
+                    continue
+                more_recent_data[field_name] = getattr(new_singleton, field_name)
+                setattr(new_singleton, field_name, getattr(old_singleton, field_name))
+            new_singleton.save()
+            for field, value in more_recent_data.items():
+                setattr(new_singleton, field, value)
+            with reversion.create_revision():
+                new_singleton.save()
+
+
+def move_non_singletons(subrecord_cls, old_parent, new_parent):
+    """
+    Moves the old_subrecords query set onto the new parent (a patient or episode).
+    In doing so it updates the previous_mrn field to be that of the old_mrn
+    """
+    if new_parent.__class__ == opal_models.Episode:
+        is_episode_subrecord = True
+    else:
+        is_episode_subrecord = False
+    if is_episode_subrecord:
+        old_subrecords = subrecord_cls.objects.filter(episode=old_parent)
+    else:
+        old_subrecords = subrecord_cls.objects.filter(patient=old_parent)
+    for old_subrecord in old_subrecords:
+        if is_episode_subrecord:
+            old_subrecord.episode = new_parent
+        else:
+            old_subrecord.patient = new_parent
+        with reversion.create_revision():
+            old_subrecord.save()
+
+
+def move_record(subrecord_cls, old_parent, new_parent):
+    if getattr(subrecord_cls, "_is_singleton", False):
+        update_singleton(subrecord_cls, old_parent, new_parent)
+    else:
+        move_non_singletons(subrecord_cls, old_parent, new_parent)
+
+
+def merge_episode(*, old_episode, new_episode):
+    for episode_related_model in merge_patient.EPISODE_RELATED_MODELS:
+        move_record(
+            episode_related_model,
+            old_episode,
+            new_episode,
+        )
+
+@transaction.atomic
+def merge_patient_episodes(patient_id):
+    patient = opal_models.Patient.objects.get(id=patient_id)
+    episodes = patient.episode_set.all()
+    category_names = list(set([i.category_name for i in episodes]))
+    for category in category_names:
+        category_episodes = [i for i in episodes if i.category_name==category]
+        if len(category_episodes) > 1:
+            root = category_episodes[0]
+            for category_episode in category_episodes[1:]:
+                merge_patient.update_tagging(category_episode, root)
+                merge_episode(old_episode=category_episode, new_episode=root)
+                category_episode_id = category_episode.id
+                patient_id = category_episode.patient_id
+                category_episode.delete()
+                with open(DELETE_FILE, 'a') as w:
+                    w.write(f'\n{patient_id},{category_episode_id}')
+
+
+def patient_ids_with_duplicate_episode_categories():
+    dups = opal_models.Episode.objects.values('patient_id', 'category_name').annotate(
+        cnt=Count('id')
+    ).filter(cnt__gte=2)
+    return [i["patient_id"] for i in dups]
+
+
+class Command(BaseCommand):
+    @timing
+    def handle(self, *args, **options):
+        dups = patient_ids_with_duplicate_episode_categories()
+        logger.info(f'Looking at {len(dups)}')
+        for idx, patient_id in enumerate(dups):
+            logger.info(f'Merging {patient_id} ({idx+1}/{len(dups)})')
+            merge_patient_episodes(patient_id)


### PR DESCRIPTION
A patient should never have multiple episodes with the same episode category.

This was not always the case. This PR merges the duplicate episode categories. The logic is mostly taken from merge_patient but does not populate previousMRN fields.

If you're happy with this, after it has been merged we should put in a database constraint, althought that might be slightly tricky as the model is in opal.

There's no reason this is not in 108. The only reason was because it is required by code going in the cerner merge branch so if you want to put it in 108, that works too.
