### PR TITLE
Send email util

### DIFF
--- a/elcid/management/commands/check_disk_space.py
+++ b/elcid/management/commands/check_disk_space.py
@@ -5,20 +5,18 @@ import datetime
 import subprocess
 
 from django.conf import settings
-from django.core.mail import send_mail
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
+from elcid.utils import send_email
 from plugins.monitoring.models import Fact
 
 
 def raise_the_alarm():
     msg = "Routine system check on {} has detected a volume with > 90% disk usage. Please log in and investigate."
-    send_mail(
-        "{} Disk Space Alert: Action Required".format(settings.OPAL_BRAND_NAME),
+    send_email(
+        "Disk Space Alert, Action Required",
         msg.format(settings.OPAL_BRAND_NAME),
-        settings.DEFAULT_FROM_EMAIL,
-        [i[1] for i in settings.ADMINS]
     )
 
 

--- a/elcid/settings.py
+++ b/elcid/settings.py
@@ -355,7 +355,7 @@ LOGGING = {
 }
 
 if 'test' not in sys.argv:
-    LOGGING['loggers']['elcid.time_logger'] = {
+    LOGGING['loggers']['elcid.utils'] = {
         'handlers': ['console_detailed'],
         'level': 'INFO',
         'propagate': False,

--- a/elcid/test/test_check_disk_space.py
+++ b/elcid/test/test_check_disk_space.py
@@ -3,19 +3,17 @@ from django.test import override_settings
 from opal.core.test import OpalTestCase
 from elcid.management.commands import check_disk_space
 
-@mock.patch("elcid.management.commands.check_disk_space.send_mail")
+@mock.patch("elcid.management.commands.check_disk_space.send_email")
 @override_settings(OPAL_BRAND_NAME="RFH")
 class CheckDiskSpaceTestCase(OpalTestCase):
-    def test_raise_the_alarm(self, send_mail):
+    def test_raise_the_alarm(self, send_email):
         check_disk_space.raise_the_alarm()
         self.assertEqual(
-            send_mail.call_args[0][0],
-            "RFH Disk Space Alert: Action Required"
+            send_email.call_args[0][0],
+            "Disk Space Alert, Action Required"
         )
         expected = "Routine system check on RFH has detected a volume with > 90% disk usage. Please log in and investigate."
         self.assertEqual(
-            send_mail.call_args[0][1],
+            send_email.call_args[0][1],
             expected
         )
-
-

--- a/elcid/utils.py
+++ b/elcid/utils.py
@@ -8,10 +8,9 @@ import os
 import re
 import sys
 from time import time
-
 from django.utils import timezone
 
-logger = logging.getLogger('elcid.time_logger')
+logger = logging.getLogger('elcid.utils')
 
 
 def timing(f):

--- a/elcid/utils.py
+++ b/elcid/utils.py
@@ -8,6 +8,8 @@ import os
 import re
 import sys
 from time import time
+from django.conf import settings
+from django.core.mail import send_mail
 from django.utils import timezone
 
 logger = logging.getLogger('elcid.utils')
@@ -76,3 +78,19 @@ def natural_keys(text):
     (See Toothy's implementation in the comments)
     '''
     return [ atoi(c) for c in re.split(r'(\d+)', text) ]
+
+
+def send_email(subject, body, html_message=None):
+    """
+    Sends an email to the admins prefixing the subject with
+    settings.DEFAULT_FROM_EMAIL
+    """
+    logger.info(f"Sending email: {subject}")
+    send_mail(
+        f"{settings.OPAL_BRAND_NAME}: {subject}",
+        body,
+        settings.DEFAULT_FROM_EMAIL,
+        [i[1] for i in settings.ADMINS],
+        html_message=html_message
+    )
+    logger.info(f"Sent email: {subject}")

--- a/intrahospital_api/management/commands/batch_load2.py
+++ b/intrahospital_api/management/commands/batch_load2.py
@@ -4,13 +4,12 @@ A management command that is run by a cron job
 import datetime
 import time
 from django.db import transaction
-from django.conf import settings
-from django.core.mail import send_mail
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from opal.models import Patient
 
 from elcid.models import Demographics
+from elcid import utils
 from intrahospital_api.loader import api
 from intrahospital_api import update_lab_tests
 from plugins.labtests.models import Observation
@@ -43,13 +42,7 @@ def send_too_many_email(since_dt, count):
         f"We found {count} lab tests which is over the threshold of {MAX_AMOUNT}.",
         "Cancelling the load"
     ])
-    logger.info(f"batch_load2: {msg}")
-    send_mail(
-        f"{settings.OPAL_BRAND_NAME}: Too many labtests",
-        msg,
-        settings.DEFAULT_FROM_EMAIL,
-        [i[1] for i in settings.ADMINS]
-    )
+    utils.send_email("Too many labtests", msg)
 
 
 class Command(BaseCommand):

--- a/intrahospital_api/management/commands/feed_alert_email.py
+++ b/intrahospital_api/management/commands/feed_alert_email.py
@@ -16,6 +16,7 @@ from plugins.labtests.models import Observation
 from plugins.imaging.models import Imaging
 from plugins.admissions.models import Encounter
 from elcid.models import MasterFileMeta
+from elcid import utils
 from intrahospital_api import logger
 
 
@@ -27,11 +28,9 @@ def send_email(title, context):
         "today": datetime.date.today()
     })
     plain_message = strip_tags(html_message)
-    send_mail(
+    utils.send_email(
         title,
         plain_message,
-        settings.DEFAULT_FROM_EMAIL,
-        settings.ADMINS,
         html_message=html_message,
     )
 
@@ -91,7 +90,7 @@ def check_feeds():
         errors.append(f"No patient information loaded since {crs_last_updated_str}")
     table_ctx["Last CRS masterfile updated"] = crs_master_file_last_updated
     if len(errors):
-        title = f"ALERT {settings.OPAL_BRAND_NAME}:" + ", ".join(errors)
+        title = f"ALERT," + ", ".join(errors)
         send_email(title, table_ctx)
 
     # Check Admissions
@@ -107,7 +106,7 @@ def check_feeds():
         )
     table_ctx["Last encounter updated"] = encounter_last_updated
     if len(errors):
-        title = f"ALERT {settings.OPAL_BRAND_NAME}:" + ", ".join(errors)
+        title = f"ALERT," + ", ".join(errors)
         send_email(title, table_ctx)
 
 


### PR DESCRIPTION
Adds a util to send admins emails in a less verbose way.

* prefixes the subject with the opal brand name
* logs before and after 