### PR TITLE
Adds the reload_patients management command

### DIFF
--- a/intrahospital_api/management/commands/reload_patients.py
+++ b/intrahospital_api/management/commands/reload_patients.py
@@ -1,0 +1,23 @@
+"""
+A management command that takes MRNs and reloads the
+associated patients.
+
+example calling code is
+
+python manage.py reload_patients 234234234 12312314
+"""
+from django.core.management.base import BaseCommand
+from opal.models import Patient
+from intrahospital_api import loader
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('mrns', nargs='+')
+
+    def handle(self, *args, **options):
+        mrns = options.get('mrns')
+        for idx, mrn in enumerate(mrns):
+            self.stdout.write(f"Looking at {mrn}, {idx+1}/{len(mrns)}")
+            patient = Patient.objects.get(demographics__hospital_number=mrn)
+            loader.load_patient(patient, run_async=False)

--- a/intrahospital_api/test/test_reload_patients_command.py
+++ b/intrahospital_api/test/test_reload_patients_command.py
@@ -1,0 +1,23 @@
+from opal.core.test import OpalTestCase
+from elcid import episode_categories as infection_episode_categories
+from intrahospital_api.management.commands import reload_patients
+from unittest import mock
+
+@mock.patch(
+	'intrahospital_api.management.commands.reload_patients.loader.load_patient'
+)
+@mock.patch(
+	'intrahospital_api.management.commands.reload_patients.loader.create_rfh_patient_from_hospital_number'
+)
+class ReloadPatientsTestCase(OpalTestCase):
+	def setUp(self):
+		self.cmd = reload_patients.Command()
+
+	def test_reloads_a_patient(self, create_rfh_patient_from_hospital_number, load_patient):
+		patient, _ = self.new_patient_and_episode_please()
+		patient.demographics_set.update(hospital_number="123")
+		with mock.patch.object(self.cmd.stdout, "write") as writer:
+			self.cmd.handle(mrns=["123"])
+		load_patient.assert_called_once_with(patient, run_async=False)
+		self.assertFalse(create_rfh_patient_from_hospital_number.called)
+		writer.assert_called_once_with("Looking at 123, 1/1")


### PR DESCRIPTION
Adds in a management command that takes in MRNs and reloads the associated patients, creating them if they do not exist.