### PR TITLE
Makes the patients name appear in tb medications and other medications

### DIFF
--- a/plugins/tb/templates/modals/other_medication.html
+++ b/plugins/tb/templates/modals/other_medication.html
@@ -2,7 +2,7 @@
 
 {% block title %}
 Other Medication
-<span ng-show="profile.can_see_pid() && editingName">
+<span ng-show="editingName">
   ([[ editingName]])
 </span>
 {% endblock %}

--- a/plugins/tb/templates/modals/tb_medication.html
+++ b/plugins/tb/templates/modals/tb_medication.html
@@ -3,7 +3,7 @@
 
 {% block title %}
 TB Medication
-<span ng-show="profile.can_see_pid() && editingName">
+<span ng-show="editingName">
   ([[ editingName]])
 </span>
 {% endblock %}


### PR DESCRIPTION
The patients name was not appearing in parenthesises in TB Medications or other medications, this is because of the old can_see_pid function that used to be in opal but is not anymore. So lets remove it.
