### PR TITLE
Changes the teams panel so read only users cannot edit it.

### DIFF
--- a/elcid/templates/_helpers/teams_panel.html
+++ b/elcid/templates/_helpers/teams_panel.html
@@ -1,0 +1,20 @@
+{% load forms %}
+<div class="panel panel-default record-panel">
+  <div class="panel-heading">
+    <h3>
+      {% icon 'fa-users' %}
+      Teams
+      <span ng-show="!profile.readonly">
+      <i class="fa fa-pencil edit pull-right"
+         ng-click="open_modal('EditTeamsCtrl', '/templates/modals/edit_teams.html', {episode: episode})"></i>
+      </span>
+    </h3>
+  </div>
+  <ul class="list-group">
+    <li class="list-group-item"
+        ng-repeat="tag in episode.getTags()"
+        ng-show="metadata.tag_visible_in_list.indexOf(tag) != -1">
+        <a href="/#/list/[[ metadata.tags[tag].slug ]]" >[[ metadata.tags[tag].display_name ]]</a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
Read only users should not be able to edit the teams modal so override the opal panel and hide the icon if the user is read only.

We use javascript because the django teams panel template tag does not pass the request context to the template.