### PR TITLE
Read only timeline

### DIFF
--- a/elcid/templates/inline_forms/clinical_timeline_base.html
+++ b/elcid/templates/inline_forms/clinical_timeline_base.html
@@ -95,26 +95,26 @@
                   </div>
                 </div>
                 <div class="col-sm-2">
+                  {% if not request.user.profile.readonly %}
                   <div class="row" ng-hide="item.sent_upstream">
                     <div class="col-md-12">
                       <i class="fa fa-pencil edit pull-right pointer" ng-click="clinicalTimeline.editItem(item)"></i>
                     </div>
                   </div>
+                  {% endif %}
                   <div class="row content-offset-10">
                     <div class="col-md-12">
                       <i class="fa fa-clipboard edit pull-right pointer" clipboard data-clipboard-target=".timeline-data-[[ $index ]]"></i>
                     </div>
                   </div>
-
+                  {% if not request.user.profile.readonly %}
                   <div class="row content-offset-10" ng-hide="item.sent_upstream">
                     <div class="col-md-12">
                       {% block send_upstream_button %}{% endblock %}
                     </div>
                   </div>
-
+                  {% endif %}
                 </div>
-
-
               </div>
             </div>
           </div>

--- a/plugins/rnoh/templates/detail/rnoh.html
+++ b/plugins/rnoh/templates/detail/rnoh.html
@@ -151,11 +151,13 @@
                     </div>
                     <div class="col-sm-2">
                       <div class="row">
+                        {% if not user.profile.readonly %}
                         <div class="col-md-12">
                           <i class="fa fa-pencil edit pull-right pointer" ng-click="clinicalTimeline.editItem(item)"></i>
                         </div>
                       </div>
                       <div class="row content-offset-10">
+                        {% endif %}
                         <div class="col-md-12">
                           <i class="fa fa-clipboard edit pull-right pointer" clipboard data-clipboard-target=".timeline-data-[[ $index ]]"></i>
                         </div>

--- a/plugins/tb/templates/detail/tb.html
+++ b/plugins/tb/templates/detail/tb.html
@@ -29,7 +29,9 @@
   <div class="col-md-6">
     {% include "partials/tb_appointments.html" %}
     {% include "partials/tb_summary_tests.html" %}
-    {% include "inline_forms/patient_consultation.html" %}
+    {% if not request.user.profile.readonly %}
+      {% include "inline_forms/patient_consultation.html" %}
+    {% endif %}
     <div ng-show="episode.patient_consultation.length" class="panel panel-default hidden-print">
       <div class="panel-body">
         <div class="patient-timeline-container">

--- a/plugins/tb/templates/detail/tb.html
+++ b/plugins/tb/templates/detail/tb.html
@@ -98,11 +98,13 @@
                   </div>
                   <div class="col-sm-2">
                     <div class="row">
+                      {% if not request.user.profile.readonly %}
                       <div class="col-md-12">
                         <i class="fa fa-pencil edit pull-right pointer" ng-click="episode.recordEditor.openEditItemModal(item, 'patient_consultation')"></i>
                       </div>
                     </div>
                     <div class="row content-offset-10">
+                      {% endif %}
                       <div class="col-md-12">
                         <i class="fa fa-clipboard edit pull-right pointer" clipboard data-clipboard-target=".consultation-timeline-data-[[ $index ]]"></i>
                       </div>
@@ -128,10 +130,12 @@
                           <i class="fa fa-envelope edit pull-right pointer"></i>
                         </a>
                       </div>
+                      {% if not request.user.profile.readonly %}
                       <div ng-hide="item.sent_upstream" class="col-md-12">
                           <i class="fa fa-exchange edit pull-right pointer"
                           ng-click="open_modal('SendPatientConsultationUpstreamCtrl', '/templates/send_upstream_modal.html', {item:item, callback: refresh, patient: patient})"></i>
                       </div>
+                      {% endif %}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Changes the timelines for the infection service, TB, RNOH and IPC so that items are read only.

Changes the TB timeline so that the inline form does not show if the user is read only (the other timelines already do this)