### PR TITLE
Make sure that readony users can't add patients from empty patient lists

### DIFF
--- a/elcid/templates/episode_list.html
+++ b/elcid/templates/episode_list.html
@@ -64,7 +64,7 @@
         <p class="lead text-center">
           There are no patients on this list.
         </p>
-        {% if not patient_list.is_read_only %}
+        {% if not patient_list.is_read_only and not request.user.profile.readonly %}
         <p class="lead text-center">
           <span class="screen-only">
             Would you like to <a href="/pathway/#/add_patient">add one</a>?


### PR DESCRIPTION
Previously if the user was on an empty patient list it would suggest they might want to add patient. This should not happen for read only users.

ie for read only users, changes 
<img width="1286" alt="Screenshot 2023-05-24 at 18 50 36" src="https://github.com/openhealthcare/elcid-rfh/assets/2175455/b61dbae8-9e0b-4b65-b270-d46400af6f1f">
to
<img width="1287" alt="Screenshot 2023-05-24 at 18 50 50" src="https://github.com/openhealthcare/elcid-rfh/assets/2175455/5485e911-30e5-4384-b340-d86265582019">
