### PR TITLE
Makes read only users not able to remove patients from patient lists

### DIFF
--- a/elcid/templates/partials/card_with_results.html
+++ b/elcid/templates/partials/card_with_results.html
@@ -21,7 +21,7 @@
               </h3>
             </div>
             <div class="col-md-2 text-right">
-              {% if not patient_list.is_read_only %}
+              {% if not patient_list.is_read_only and not request.user.profile.readonly %}
               <button class="btn btn-primary" pathway-episode="row" open-pathway="remove" pathway-callback="removeFromList(row.id)">
                 {% icon 'fa-sign-out' %} Remove
               </button>


### PR DESCRIPTION
Hides the remove patient button from patient lists if the user is read only.
Changes
<img width="1183" alt="Screenshot 2023-05-24 at 18 54 16" src="https://github.com/openhealthcare/elcid-rfh/assets/2175455/e82f91fc-7586-4a1f-94ce-c8d0a94956de">
to
<img width="1181" alt="Screenshot 2023-05-24 at 18 54 04" src="https://github.com/openhealthcare/elcid-rfh/assets/2175455/e307bd88-d3be-4a08-b0cc-18c585f85259">

