### PR TITLE
Makes read only users unable to interact with the TB review list

### DIFF
--- a/plugins/tb/templates/partials/tb_appointments.html
+++ b/plugins/tb/templates/partials/tb_appointments.html
@@ -61,6 +61,7 @@
         >
           TB Review Patients
         </a>
+        {% if not request.user.profile.readonly %}
         <button
           ng-hide="episode.tagging[0].tb_review_patients"
           ng-click="open_modal('AddRemoveTagCtrl', '/templates/modals/add_remove_tag.html', {episode: episode, tagName: 'tb_review_patients', tagDisplayName: 'TB Review Patients', addTag: true})"
@@ -77,6 +78,7 @@
           <i class="fa fa-sign-out"></i>
           Remove
         </button>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
If the user is read only they should not be able to add/remove patients from/to the TB review list

Changes 
<img width="529" alt="Screenshot 2023-05-25 at 09 42 49" src="https://github.com/openhealthcare/elcid-rfh/assets/2175455/0fd875ea-4b3c-4cbf-a904-b951efe50a6b">

To
<img width="530" alt="Screenshot 2023-05-25 at 09 43 01" src="https://github.com/openhealthcare/elcid-rfh/assets/2175455/a63ee45a-e0ec-4cb0-bc5c-e37d760b9403">
