### PR TITLE
Bugfix: TB API

### DIFF
--- a/plugins/tb/api.py
+++ b/plugins/tb/api.py
@@ -55,6 +55,15 @@ class TbTests(LoginRequiredViewset):
 
     @patient_from_pk
     def retrieve(self, request, patient):
+        tb_patient = patient.episode_set.filter(category_name=TBEpisode.display_name).exists()
+        # There is nowhere in the UI where these results are displayed if no TB episode
+        # exists, but due to questionable implementation details of episode detail views,
+        # sometimes this can be called for non-tb patients.
+        # If they have old -ve TB screening tests this raises an exception - prevent that
+        # by simply returning fast.
+        if not tb_patient:
+            return json_response({})
+
         # observations of a singl test are split across models, fetch them
         # and group them back by lab number
         smears = list(models.AFBSmear.objects.filter(

--- a/plugins/tb/tests/test_api.py
+++ b/plugins/tb/tests/test_api.py
@@ -84,3 +84,25 @@ class TestMultipleResults(OpalTestCase):
             ]
         }
         self.assertEqual(result.json(), expected)
+
+
+class TestTBTests(OpalTestCase):
+
+    def setUp(self):
+        self.request = self.rf.get("/")
+        self.patient, _ = self.new_patient_and_episode_please()
+        self.url = reverse(
+            'tb_tests-detail',
+            kwargs={"pk": self.patient.id},
+            request=self.request
+        )
+        self.assertTrue(
+            self.client.login(
+                username=self.user.username, password=self.PASSWORD
+            )
+        )
+
+    def test_no_TB_epispde(self):
+        result = self.client.get(self.url)
+        expected = {}
+        self.assertEqual(result.json(), expected)


### PR DESCRIPTION
Error email fixup:

Return empty but don't 500 if we hit the TB test summary API for a patient with no TB Episode

There is nowhere in the UI where these results are displayed if no TB episode
exists, but due to questionable implementation details of episode detail views,
sometimes this can be called for non-tb patients.
If they have old -ve TB screening tests this raises an exception - prevent that
 by simply returning fast.